### PR TITLE
flesh out patching of sqlite tables

### DIFF
--- a/coopy/SqlCompare.hx
+++ b/coopy/SqlCompare.hx
@@ -171,6 +171,10 @@ class SqlCompare {
             }
         }
         align.meta.range(all_cols1.length,all_cols2.length);
+        for (key in key_cols) {
+            var unit = new Unit(present1.get(key),present2.get(key));
+            align.addIndexColumns(unit);
+        }
 
         align.tables(local,remote);
 
@@ -255,7 +259,11 @@ class SqlCompare {
 
         var sql_inserts : String = "SELECT DISTINCT NULL, " + rowid + " AS rowid, " + sql_all_cols2 + " FROM " + sql_table2 + " WHERE NOT EXISTS (SELECT 1 FROM " + sql_table1 + where(sql_key_match) + ")";
         var sql_inserts_order : Array<String> = ["NULL","rowid"].concat(all_cols2);
-        var sql_updates : String = "SELECT DISTINCT " + rowid1 + " AS __coopy_rowid0, " + rowid2 + " AS __coopy_rowid1, " + sql_dbl_cols + " FROM " + sql_table1 + " INNER JOIN " + sql_table2 + " ON " + sql_key_match + where(sql_data_mismatch);
+        var sql_updates : String = "SELECT DISTINCT " + rowid1 + " AS __coopy_rowid0, " + rowid2 + " AS __coopy_rowid1, " + sql_dbl_cols + " FROM " + sql_table1;
+        if (sql_table1 != sql_table2) {
+            sql_updates += " INNER JOIN " + sql_table2 + " ON " + sql_key_match;
+        }
+        sql_updates += where(sql_data_mismatch);
         var sql_updates_order : Array<String> = ["__coopy_rowid0", "__coopy_rowid1"].concat(dbl_cols);
         var sql_deletes : String = "SELECT DISTINCT " + rowid + " AS rowid, NULL, " + sql_all_cols1 + " FROM " + sql_table1 + " WHERE NOT EXISTS (SELECT 1 FROM " + sql_table2 + where(sql_key_match) + ")";
         var sql_deletes_order : Array<String> = ["rowid","NULL"].concat(all_cols1);

--- a/coopy/SqlHelper.hx
+++ b/coopy/SqlHelper.hx
@@ -14,4 +14,5 @@ interface SqlHelper {
                     conds: Map<String, Dynamic>,
                     vals: Map<String, Dynamic>) : Bool;
     function attach(db: SqlDatabase, tag: String, resource_name: String) : Bool;
+    function alterColumns(db: SqlDatabase, name: SqlTableName, columns : Array<ColumnChange>) : Bool;
 }

--- a/coopy/SqlTable.hx
+++ b/coopy/SqlTable.hx
@@ -78,6 +78,8 @@ class SqlTable implements Table implements Meta implements RowStream {
             if (y>=0) {
                 y = id2rid[y];
             }
+        } else if (y==0) {
+            y = -1;
         }
         if (y<0) {
             getColumns();
@@ -166,7 +168,10 @@ class SqlTable implements Table implements Meta implements RowStream {
     }
 
     public function alterColumns(columns : Array<ColumnChange>) : Bool {
-        return false;
+        // pass the request on, too db-specific to do anything useful here
+        var result = helper.alterColumns(db,name,columns);
+        this.columns = null;
+        return result;
     }
 
     public function changeRow(rc: RowChange) : Bool {
@@ -191,10 +196,12 @@ class SqlTable implements Table implements Meta implements RowStream {
         var mt = new SimpleTable(w+1,pct);
         mt.setCell(0,0,"@");
         mt.setCell(0,1,"type");
+        mt.setCell(0,2,"pkey");
         for (x in 0...w) {
             var i = x+1;
             mt.setCell(i,0,columnNames[x]);
             mt.setCell(i,1,columns[x].type_value);
+            mt.setCell(i,2,columns[x].primary ? 1 : 0);
         }
         return mt;
     }

--- a/env/js/sqlite_database.js
+++ b/env/js/sqlite_database.js
@@ -20,7 +20,7 @@ if (typeof exports != "undefined") {
 	}
 	
 	SqliteDatabase.prototype.getQuotedTableName = function (name) {
-	    return name;
+	    return name.toString();
 	}
 	
 	SqliteDatabase.prototype.getColumns = function(name) {

--- a/env/py/sqlite_database.py
+++ b/env/py/sqlite_database.py
@@ -3,6 +3,7 @@ import sqlite3
 class SqliteDatabase(SqlDatabase):
     def __init__(self,db,fname):
         self.db = db
+        db.isolation_level = None
         self.fname = fname
         self.cursor = db.cursor()
         self.row = None

--- a/harness/SqlTest.hx
+++ b/harness/SqlTest.hx
@@ -75,4 +75,24 @@ class SqlTest extends haxe.unit.TestCase {
         assertEquals(20,out.getCell(2,3));
         assertEquals("Naomi",out.getCell(3,3));
     }
+
+    public function comparePair(name1: String, name2: String) {
+        setup();
+        var st1 = new coopy.SqlTable(db,new coopy.SqlTableName(name1));
+        var st2 = new coopy.SqlTable(db,new coopy.SqlTableName(name2));
+        flags.show_meta = true;
+        var out = coopy.Coopy.diff(st1,st2,flags);
+        coopy.Coopy.patch(st1,out);
+        out = coopy.Coopy.diff(st1,st2,flags);
+        assertTrue(out.height<=1);
+    }
+
+    public function testColumnPatch() {
+        var names = ["ver1", "ver2", "ver3", "ver4"];
+        for (n1 in names) {
+            for (n2 in names) {
+                comparePair(n1,n2);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This implements patching an sqlite table, using a daff-generated diff. It avoids loading the full table into memory, with all operations offloaded to sql.