### PR TITLE
implement 3-way comparison for sqlite

### DIFF
--- a/coopy/CompareFlags.hx
+++ b/coopy/CompareFlags.hx
@@ -164,6 +164,15 @@ class CompareFlags {
      */
     public var show_unchanged_meta : Bool;
 
+
+    /**
+     *
+     * Set a common ancestor for use in comparison.  Defaults to null
+     * (no known common ancestor).
+     *
+     */
+    public var parent : Table;
+
     public function new() {
         ordered = true;
         show_unchanged = false;
@@ -182,6 +191,7 @@ class CompareFlags {
         show_meta = true;
         show_unchanged_meta = false;
         tables = null;
+        parent = null;
     }
 
     /**

--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -179,7 +179,7 @@ class Coopy {
         var hp : HighlightPatch = new HighlightPatch(null,null);
         var csv : Csv = new Csv();
         var tm : TableModifier = new TableModifier(null);
-        var sc: SqlCompare = new SqlCompare(null,null,null);
+        var sc: SqlCompare = new SqlCompare(null,null,null,null);
 
         return 0;
     }

--- a/coopy/Ordering.hx
+++ b/coopy/Ordering.hx
@@ -45,6 +45,17 @@ class Ordering {
 
     /**
      *
+     * Replace the order with a prepared list.
+     *
+     * @param lst the new order
+     *
+     */
+    public function setList(lst: Array<Unit>) {
+        order = lst;
+    }
+
+    /**
+     *
      * @return the list of units in text form
      *
      */

--- a/coopy/SimpleTable.hx
+++ b/coopy/SimpleTable.hx
@@ -68,6 +68,29 @@ class SimpleTable implements Table {
      *
      */
     public static function tableToString(tab : Table) : String {
+        var meta = tab.getMeta();
+        if (meta!=null) {
+            var stream = meta.getRowStream();
+            if (stream!=null) {
+                var x : String = "";
+                var cols = stream.fetchColumns();
+                for (i in 0...cols.length) {
+                    if (i>0) x += ",";
+                    x += cols[i];
+                }
+                x += "\n";
+                var row : Map<String,Dynamic> = stream.fetchRow();
+                while(row!=null) {
+                    for (i in 0...cols.length) {
+                        if (i>0) x += ",";
+                        x += row[cols[i]];
+                    }
+                    x += "\n";
+                    row = stream.fetchRow();
+                }
+                return x;
+            }
+        }
         var x : String = "";
         for (i in 0...tab.height) {
             for (j in 0...tab.width) {
@@ -89,6 +112,12 @@ class SimpleTable implements Table {
      *
      */
     public static function tableIsSimilar(tab1 : Table, tab2 : Table) : Bool {
+        if (tab1.height==-1 || tab2.height==-1) {
+            // At least one table is streaming.
+            var txt1 = tableToString(tab1);
+            var txt2 = tableToString(tab2);
+            return txt1 == txt2;
+        }
         if (tab1.width!=tab2.width) return false;
         if (tab1.height!=tab2.height) return false;
         var v = tab1.getCellView();

--- a/coopy/SimpleView.hx
+++ b/coopy/SimpleView.hx
@@ -22,7 +22,6 @@ class SimpleView implements View {
     }
     
     public function equals(d1: Dynamic, d2: Dynamic) : Bool {
-        //trace("Comparing " + d1 + " and " + d2 + " -- " +  (("" + d1) == ("" + d2)));
         if (d1==null && d2==null) return true;
         if (d1==null && (""+d2)=="") return true;
         if ((""+d1)=="" && d2==null) return true;

--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -533,6 +533,11 @@ class TableDiff {
                         output.setCell(j+1,at,
                                        b.getCell(cunit.r,rb_header));
                     }
+                } else if (cunit.l>=0) {
+                    if (a.height!=0) {
+                        output.setCell(j+1,at,
+                                       a.getCell(cunit.l,ra_header));
+                    }
                 } else if (cunit.lp()>=0) {
                     if (p.height!=0) {
                         output.setCell(j+1,at,
@@ -684,7 +689,7 @@ class TableDiff {
                 } else {
                     // have_pp, have_rr
                     if (v.equals(pp,rr)) {
-                        dd = pp;
+                        dd = ll;
                     } else {
                         // rr is different
                         dd = pp;

--- a/env/js/util.js
+++ b/env/js/util.js
@@ -64,7 +64,7 @@ if (typeof exports != "undefined") {
 
     tio.openSqliteDatabase = function(path) {
 	if (Fiber) {
-	    return new SqliteDatabase(new sqlite3.Database(path),path,Fiber);
+	    return new coopy.SqliteDatabase(new sqlite3.Database(path),path,Fiber);
 	}
 	throw("run inside Fiber plz");
 	return null;

--- a/harness/BasicTest.hx
+++ b/harness/BasicTest.hx
@@ -5,6 +5,8 @@ package harness;
 class BasicTest extends haxe.unit.TestCase {
     var data1 : Array<Array<Dynamic>>;
     var data2 : Array<Array<Dynamic>>;
+    var data3 : Array<Array<Dynamic>>;
+    var data4 : Array<Array<Dynamic>>;
 
     override public function setup() {
         data1 = [['Country','Capital'],
@@ -16,8 +18,17 @@ class BasicTest extends haxe.unit.TestCase {
                  ['France','fr','Paris'],
                  ['Spain','es','Madrid'],
                  ['Germany','de','Berlin']];
+        data3 = [['Country','Capital','Time'],
+                 ['Ireland','Baile Atha Cliath',0],
+                 ['France','Paris',1],
+                 ['Spain','Barcelona',1]];
+        data4 = [['Country','Code','Capital','Time'],
+                 ['Ireland','ie','Baile Atha Cliath',0],
+                 ['France','fr','Paris',1],
+                 ['Spain','es','Madrid',1],
+                 ['Germany','de','Berlin',null]];
     }
-    
+
     public function testBasic(){
         var table1 = Native.table(data1);
         var table2 = Native.table(data2);
@@ -104,5 +115,18 @@ class BasicTest extends haxe.unit.TestCase {
         var render1 = new coopy.DiffRender().render(table_diff1).html();
         var render2 = new coopy.DiffRender().render(table_diff2).html();
         assertEquals(render1,render2);
+    }
+
+    public function testThreeWay() {
+        var flags = new coopy.CompareFlags();
+        var table1 = Native.table(data1);
+        var table2 = Native.table(data2);
+        var table3 = Native.table(data3);
+        var table4 = Native.table(data4);
+        flags.parent = table1;
+        var out = coopy.Coopy.diff(table2,table3,flags);
+        var table2b = table2.clone();
+        coopy.Coopy.patch(table2b,out);
+        assertTrue(coopy.SimpleTable.tableIsSimilar(table4,table2b));
     }
 }

--- a/harness/MergeTest.hx
+++ b/harness/MergeTest.hx
@@ -27,17 +27,17 @@ class MergeTest extends haxe.unit.TestCase {
         data4 = [['Country','Code','Capital'],
                  ['Dear old Ireland','ie','Dublin'],
                  ['Spain','es','Madrid'],
-                 ['Germany','de','Berlin'],
-                 ['Finland',null,'Helsinki']];
+                 ['Finland',null,'Helsinki'],
+                 ['Germany','de','Berlin']];
         data3b = [['Country','Capital'],
                  ['Dear old Ireland','Dublin'],
                  ['Spain','Lisbon'],
                  ['Finland','Helsinki']];
         data4b = [['Country','Code','Capital'],
-                 ['Dear old Ireland','ie','Dublin'],
-                 ['Spain','es','((( Barcelona ))) Madrid /// Lisbon'],
-                 ['Germany','de','Berlin'],
-                 ['Finland',null,'Helsinki']];
+                  ['Dear old Ireland','ie','Dublin'],
+                  ['Spain','es','((( Barcelona ))) Madrid /// Lisbon'],
+                  ['Finland',null,'Helsinki'],
+                  ['Germany','de','Berlin']];
     }
     
     public function testUnconflicted(){

--- a/harness/Native.hx
+++ b/harness/Native.hx
@@ -154,7 +154,8 @@ class Native {
 
     static public function openSqlite(name: String) : coopy.SqlDatabase {
 #if js
-    return untyped __js__("new SqliteDatabase(new sqlite3.Database(name),name,Fiber)");
+        untyped __js__("if (typeof daff == 'undefined') { GLOBAL.daff = require('daff'); }");
+    return untyped __js__("new daff.SqliteDatabase(new sqlite3.Database(name),name,Fiber)");
 #elseif python
     python.Syntax.pythonCode("daff = __import__('daff')");
     return python.Syntax.pythonCode("daff.SqliteDatabase(daff.sqlite3.connect(name),name)");

--- a/harness/SqlTest.hx
+++ b/harness/SqlTest.hx
@@ -12,18 +12,33 @@ class SqlTest extends haxe.unit.TestCase {
         exec(db,"CREATE TABLE ver2 (id INTEGER PRIMARY KEY, name TEXT)");
         exec(db,"CREATE TABLE ver3 (id INTEGER PRIMARY KEY, name TEXT, count INTEGER)");
         exec(db,"CREATE TABLE ver4 (id INTEGER PRIMARY KEY, count INTEGER)");
+        exec(db,"CREATE TABLE ver5 (id INTEGER PRIMARY KEY, happy INTEGER, name TEXT)");
+        exec(db,"CREATE TABLE ver6 (id INTEGER PRIMARY KEY, happy INTEGER, name TEXT)");
+
         exec(db,"INSERT INTO ver1 VALUES(?,?)",[1, "Paul"]);
         exec(db,"INSERT INTO ver1 VALUES(?,?)",[2, "Naomi"]);
         exec(db,"INSERT INTO ver1 VALUES(?,?)",[4, "Hobbes"]);
+
         exec(db,"INSERT INTO ver2 VALUES(?,?)",[2, "Noemi"]);
         exec(db,"INSERT INTO ver2 VALUES(?,?)",[3, "Calvin"]);
         exec(db,"INSERT INTO ver2 VALUES(?,?)",[4, "Hobbes"]);
+
         exec(db,"INSERT INTO ver3 VALUES(?,?,?)",[2, "Noemi", 20]);
         exec(db,"INSERT INTO ver3 VALUES(?,?,?)",[3, "Calvin", 50]);
         exec(db,"INSERT INTO ver3 VALUES(?,?,?)",[4, "Hobbes", 92]);
+
         exec(db,"INSERT INTO ver4 VALUES(?,?)",[2, 20]);
         exec(db,"INSERT INTO ver4 VALUES(?,?)",[3, 50]);
         exec(db,"INSERT INTO ver4 VALUES(?,?)",[4, 92]);
+
+        exec(db,"INSERT INTO ver5 VALUES(?,?,?)",[1, 88, "Paul"]);
+        exec(db,"INSERT INTO ver5 VALUES(?,?,?)",[2, 77, "Naomi"]);
+        exec(db,"INSERT INTO ver5 VALUES(?,?,?)",[4, 88, "Hobbesian"]);
+
+        exec(db,"INSERT INTO ver6 VALUES(?,?,?)",[2, 77, "Noemi"]);
+        exec(db,"INSERT INTO ver6 VALUES(?,?,?)",[3, null, "Calvin"]);
+        exec(db,"INSERT INTO ver6 VALUES(?,?,?)",[4, 88, "Hobbesian"]);
+
         flags = new coopy.CompareFlags();
         flags.diff_strategy = "sql";
         flags.show_meta = false;
@@ -38,7 +53,7 @@ class SqlTest extends haxe.unit.TestCase {
 
         var st1 = new coopy.SqlTable(db,new coopy.SqlTableName("ver1"));
         var st2 = new coopy.SqlTable(db,new coopy.SqlTableName("ver2"));
-        var sc = new coopy.SqlCompare(db,st1,st2);
+        var sc = new coopy.SqlCompare(db,st1,st2,null);
         var alignment = sc.apply();
     
         var flags = new coopy.CompareFlags();
@@ -53,7 +68,7 @@ class SqlTest extends haxe.unit.TestCase {
         assertTrue(coopy.SimpleTable.tableIsSimilar(target,out));
         coopy.Coopy.patch(st1,target);
 
-        var sc2 = new coopy.SqlCompare(db,st1,st2);
+        var sc2 = new coopy.SqlCompare(db,st1,st2,null);
         var alignment2 = sc2.apply();
         var td = new coopy.TableDiff(alignment2,flags);
         var out2 = Native.table([]);
@@ -94,5 +109,16 @@ class SqlTest extends haxe.unit.TestCase {
                 comparePair(n1,n2);
             }
         }
+    }
+
+    public function test3WayDiff() {
+        var st1 = new coopy.SqlTable(db,new coopy.SqlTableName("ver1"));
+        var st2 = new coopy.SqlTable(db,new coopy.SqlTableName("ver2"));
+        var st5 = new coopy.SqlTable(db,new coopy.SqlTableName("ver5"));
+        var st6 = new coopy.SqlTable(db,new coopy.SqlTableName("ver6"));
+        flags.parent = st1;
+        var out = coopy.Coopy.diff(st2,st5,flags);
+        coopy.Coopy.patch(st2,out);
+        assertTrue(coopy.SimpleTable.tableIsSimilar(st2,st6));
     }
 }

--- a/scripts/tester.js
+++ b/scripts/tester.js
@@ -21,8 +21,9 @@ function order_asserts(order,lst) {
 function align_assert(align,a,b) {
     var msg = "alignment " + align + " " + a + " -> " + b;
     if (a==null) {
-	assert(align.b2a(b)==null,msg);
+	assert(align.b2a(b)==-1,msg);
     } else {
+        if (b==null) b = -1;
 	assert(align.a2b(a)==b,msg);
     }
 }

--- a/test/test_3way_alignment.js
+++ b/test/test_3way_alignment.js
@@ -48,8 +48,8 @@ var tester = require('tester');
 			  [1,1,1],
 			  [2,3,3],
 			  [3,4,4],
-			  [-1,-1,5],
-			  [4,2,2]]);
+			  [4,2,2],
+			  [-1,-1,5]]);
     tester.order_asserts(align.meta.toOrder(),
 			 [[0,0,0]]);
 }

--- a/test/test_column_alignment.js
+++ b/test/test_column_alignment.js
@@ -64,7 +64,7 @@ var tester = require('tester');
     var ct = new coopy.Coopy.compareTables(t1,t2);
     var align = ct.align();
     tester.order_asserts(align.meta.toOrder(),
-		  [[2,0],[0,1],[1,-1]]);
+		  [[1,-1],[2,0],[0,1]]);
     tester.order_asserts(align.toOrder(),
 			 [[0,0],[1,1],[2,2],[-1,3],[3,-1]]);
 }

--- a/test/test_sqlite.py
+++ b/test/test_sqlite.py
@@ -19,7 +19,7 @@ sd = daff.SqliteDatabase(db,None)
 st1 = daff.SqlTable(sd,daff.SqlTableName("ver1"))
 st2 = daff.SqlTable(sd,daff.SqlTableName("ver2"))
 
-sc = daff.SqlCompare(sd,st1,st2)
+sc = daff.SqlCompare(sd,st1,st2,None)
 
 align = sc.apply()
 


### PR DESCRIPTION
This completes sql-based diffs between tables for which a common ancestor is known.  It also makes some fixes so that the content of sql tables need not to be loaded into memory in order to correctly render the diffs.