### PR TITLE
implement --ignore-whitespace / -w flag, see #36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 install:
   - sudo apt-get install time php5 -y
   - if ! $USE_PAULFITZ; then sudo apt-get install haxe -y; fi
-  - if $USE_PAULFITZ; then wget https://github.com/paulfitz/haxe/releases/download/rb_v3.1.1_9/haxerb.zip; fi
+  - if $USE_PAULFITZ; then wget https://github.com/paulfitz/haxe/releases/download/rb_v3.1.1_10/haxerb.zip; fi
   - if $USE_PAULFITZ; then unzip -q haxerb.zip; fi
   - sudo apt-get install gcc-multilib g++-multilib -y  # VM is 64bit but hxcpp builds 32bit
   - mkdir -p ~/haxelib

--- a/coopy/CompareFlags.hx
+++ b/coopy/CompareFlags.hx
@@ -182,6 +182,13 @@ class CompareFlags {
      */
     public var count_like_a_spreadsheet : Bool;
 
+    /**
+     *
+     * Should whitespace be omitted from comparisons.  Defaults to false.
+     *
+     */
+    public var ignore_whitespace : Bool;
+
     public function new() {
         ordered = true;
         show_unchanged = false;
@@ -202,6 +209,7 @@ class CompareFlags {
         tables = null;
         parent = null;
         count_like_a_spreadsheet = true;
+        ignore_whitespace = false;
     }
 
     /**

--- a/coopy/CompareTable.hx
+++ b/coopy/CompareTable.hx
@@ -162,7 +162,7 @@ class CompareTable {
             // no need for heuristics, we've been told what columns
             // to use as a primary key
 
-            index_top = new IndexPair();
+            index_top = new IndexPair(comp.compare_flags);
             var ids_as_map = new Map<String,Bool>();
             for (id in ids) {
                 ids_as_map[id] = true;
@@ -262,7 +262,7 @@ class CompareTable {
                     at++;
                 }
 
-                var index : IndexPair = new IndexPair();
+                var index : IndexPair = new IndexPair(comp.compare_flags);
                 for (k in 0...active_columns.length) {
                     var col : Int = active_columns[k];
                     var unit : Unit = common_units[col];

--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -173,9 +173,9 @@ class Coopy {
         var st : SimpleTable = new SimpleTable(1,1);
         var v : Viterbi = new Viterbi();
         var td : TableDiff = new TableDiff(null,null);
-        var idx : Index = new Index();
-        var dr : DiffRender = new DiffRender();
         var cf : CompareFlags = new CompareFlags();
+        var idx : Index = new Index(cf);
+        var dr : DiffRender = new DiffRender();
         var hp : HighlightPatch = new HighlightPatch(null,null);
         var csv : Csv = new Csv();
         var tm : TableModifier = new TableModifier(null);
@@ -708,6 +708,11 @@ class Coopy {
                     flags.addTable(args[i+1]);
                     args.splice(i,2);
                     break;
+                } else if (tag=="-w" || tag=="--ignore-whitespace") {
+                    more = true;
+                    flags.ignore_whitespace = true;
+                    args.splice(i,1);
+                    break;
                 }
             }
         }
@@ -778,6 +783,7 @@ class Coopy {
             io.writeStderr("     --output-format [csv|tsv|ssv|json|copy|html]: set format for output\n");
             io.writeStderr("     --table NAME:  compare the named table, used with SQL sources\n");
             io.writeStderr("     --unordered:   assume row order is meaningless (default for json formats)\n");
+            io.writeStderr("     -w / --ignore-whitespace: ignore changes in leading/trailing whitespace\n");
             io.writeStderr("\n");
             io.writeStderr("  daff render [--output OUTPUT.html] [--css CSS.css] [--fragment] [--plain] diff.csv\n");
             io.writeStderr("     --css CSS.css: generate a suitable css file to go with the html\n");

--- a/coopy/Index.hx
+++ b/coopy/Index.hx
@@ -15,14 +15,19 @@ class Index {
     private var v : View;
     private var indexed_table : Table;
     private var hdr : Int;
+    private var ignore_whitespace : Bool;
 
-    public function new() : Void {
+    public function new(flags : CompareFlags) : Void {
         items = new Map<String,IndexItem>();
         cols = new Array<Int>();
         keys = new Array<String>();
         top_freq = 0;
         height = 0;
         hdr = 0;
+        ignore_whitespace = false;
+        if (flags!=null) {
+            ignore_whitespace = flags.ignore_whitespace;
+        }
     }
  
     public function addColumn(i: Int) : Void {
@@ -60,6 +65,9 @@ class Index {
         for (k in 0...cols.length) {
             var d : Dynamic = t.getCell(cols[k],i);
             var txt : String = v.toString(d);
+            if (ignore_whitespace) {
+                txt = StringTools.trim(txt);
+            }
             if (k>0) wide += " // ";
             if (txt==null || txt=="" || txt=="null" || txt=="undefined") continue;
             wide += txt;
@@ -71,6 +79,9 @@ class Index {
         var wide : String = row.isPreamble()?"_":"";
         for (k in 0...cols.length) {
             var txt : String = row.getRowString(cols[k]);
+            if (ignore_whitespace) {
+                txt = StringTools.trim(txt);
+            }
             if (k>0) wide += " // ";
             if (txt==null || txt=="" || txt=="null" || txt=="undefined") continue;
             wide += txt;

--- a/coopy/IndexPair.hx
+++ b/coopy/IndexPair.hx
@@ -17,13 +17,15 @@ class IndexPair {
     private var ib : Index;
     private var hdr : Int;
     private var quality : Float;
+    private var flags : CompareFlags;
 
-    public function new() : Void {
-        ia = new Index();
-        ib = new Index();
+    public function new(flags: CompareFlags) : Void {
+        this.flags = flags;
+        ia = new Index(flags);
+        ib = new Index(flags);
         quality = 0;
         hdr = 0;
-    }
+       }
 
     /**
      *

--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -632,6 +632,13 @@ class TableDiff {
         }
     }
 
+    private function isEqual(v: View, aa: Dynamic, bb: Dynamic) {
+        if (flags.ignore_whitespace) {
+            return StringTools.trim(v.toString(aa)) == StringTools.trim(v.toString(bb));
+        }
+        return v.equals(aa,bb);
+    }
+
     /**
      *
      * Generate diff for given l/r/p row unit #i.
@@ -688,7 +695,7 @@ class TableDiff {
                     dd = pp;
                 } else {
                     // have_pp, have_rr
-                    if (v.equals(pp,rr)) {
+                    if (isEqual(v,pp,rr)) {
                         dd = ll;
                     } else {
                         // rr is different
@@ -696,8 +703,8 @@ class TableDiff {
                         dd_to = rr;
                         have_dd_to = true;
 
-                        if (!v.equals(pp,ll)) {
-                            if (!v.equals(pp,rr)) {
+                        if (!isEqual(v,pp,ll)) {
+                            if (!isEqual(v,pp,rr)) {
                                 dd_to_alt = ll;
                                 have_dd_to_alt = true;
                             }
@@ -708,7 +715,7 @@ class TableDiff {
                 if (!have_rr) {
                     dd = ll;
                 } else {
-                    if (v.equals(ll,rr)) {
+                    if (isEqual(v,ll,rr)) {
                         dd = ll;
                     } else {
                         // rr is different
@@ -739,7 +746,7 @@ class TableDiff {
                 }
                 var is_conflict : Bool = false;
                 if (have_dd_to_alt) {
-                    if (!v.equals(dd_to,dd_to_alt)) {
+                    if (!isEqual(v,dd_to,dd_to_alt)) {
                         is_conflict = true;
                     }
                 }

--- a/harness/Main.hx
+++ b/harness/Main.hx
@@ -18,7 +18,8 @@ class Main {
                      new SpeedTest(), 
                      new JsonTest(), 
                      new MetaTest(),
-                     new PatchTest()
+                     new PatchTest(),
+                     new WhiteSpaceTest()
                      ];
 
         if (Native.hasSqlite()) {

--- a/harness/WhiteSpaceTest.hx
+++ b/harness/WhiteSpaceTest.hx
@@ -1,0 +1,39 @@
+// -*- mode:java; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+package harness;
+
+class WhiteSpaceTest extends haxe.unit.TestCase {
+    var data1 : Array<Array<Dynamic>>;
+    var data2 : Array<Array<Dynamic>>;
+    var data3 : Array<Array<Dynamic>>;
+
+    override public function setup() {
+        data1 = [['Country','Capital'],
+                 ['  Ireland','Dublin'],
+                 ['France',15],
+                 ['Spain','     Barcelona']];
+        data2 = [['Country','Capital'],
+                 ['Ireland','  Dublin'],
+                 ['France',15],
+                 ['Spain','  Barcelona  ']];
+        data3 = [['Country','Capital'],
+                 ['Ireland','  Dublin'],
+                 ['France',15],
+                 ['Spain','  Madrid  ']];
+    }
+
+    public function testBasic(){
+        var table1 = Native.table(data1);
+        var table2 = Native.table(data2);
+        var flags = new coopy.CompareFlags();
+        flags.unchanged_context = 0;
+        var o = coopy.Coopy.diff(table1,table2,flags);
+        assertEquals(4,o.height);
+        flags.ignore_whitespace = true;
+        o = coopy.Coopy.diff(table1,table2,flags);
+        assertEquals(1,o.height);
+        var table3 = Native.table(data3);
+        o = coopy.Coopy.diff(table1,table3,flags);
+        assertEquals(2,o.height);
+    }
+}


### PR DESCRIPTION
This adds an `--ignore-whitespace`/`-w` flag that treats cells that differ only in leading or trailing whitespace as identical.