### PR TITLE
implement multi-table comparison for sqlite sources

### DIFF
--- a/coopy/Alignment.hx
+++ b/coopy/Alignment.hx
@@ -23,9 +23,13 @@ class Alignment {
     private var order_cache : Ordering;
     private var order_cache_has_reference : Bool;
     private var index_columns : Array<Unit>;
+    private var marked_as_identical : Bool;
 
     public var reference: Alignment;
     public var meta: Alignment;
+    public var comp: TableComparisonState;
+    public var has_addition : Bool;
+    public var has_removal : Bool;
 
     public function new() : Void {
         map_a2b = new Map<Int,Int>();
@@ -34,9 +38,11 @@ class Alignment {
         map_count = 0;
         reference = null;
         meta = null;
+        comp = null;
         order_cache_has_reference = false;
         ia = -1;
         ib = -1;
+        marked_as_identical = false;
     }
 
     /**
@@ -95,8 +101,16 @@ class Alignment {
      *
      */
     public function link(a: Int, b: Int) : Void {
-        if (a!=-1) map_a2b.set(a,b);
-        if (b!=-1) map_b2a.set(b,a);
+        if (a!=-1) {
+            map_a2b.set(a,b);
+        } else {
+            has_addition = true;
+        }
+        if (b!=-1) {
+            map_b2a.set(b,a);
+        } else {
+            has_removal = true;
+        }
         map_count++;
     }
 
@@ -381,5 +395,13 @@ class Alignment {
         result.setList(order);
         if (reference==null) result.ignoreParent();
         return result;
+    }
+
+    public function markIdentical() {
+        marked_as_identical = true;
+    }
+
+    public function isMarkedAsIdentical() : Bool {
+        return marked_as_identical;
     }
 }

--- a/coopy/CompareFlags.hx
+++ b/coopy/CompareFlags.hx
@@ -117,8 +117,6 @@ class CompareFlags {
      *
      * List of tables to process.  Used when reading from a source
      * with multiple tables.  Defaults to null, meaning all tables.
-     * WARNING: currently only a single table can actually be
-     * processed.
      *
      */
     public var tables : Array<String>;

--- a/coopy/Meta.hx
+++ b/coopy/Meta.hx
@@ -88,4 +88,26 @@ interface Meta {
      *
      */
     function getRowStream() : RowStream;
+
+
+    /**
+     *
+     * @return true if the table may be nested (containing subtables).
+     *
+     */
+    function isNested() : Bool;
+
+    /**
+     *
+     * @return true if the table is best accessed via sql.
+     *
+     */
+    function isSql() : Bool;
+
+    /**
+     *
+     * @return a name for the table if it has one, otherwise null.
+     *
+     */
+    function getName() : String;
 }

--- a/coopy/SimpleMeta.hx
+++ b/coopy/SimpleMeta.hx
@@ -18,12 +18,15 @@ class SimpleMeta implements Meta {
     private var keys : Map<String,Bool>;
     private var row_active : Bool;
     private var row_change_cache : Array<RowChange>;
+    private var may_be_nested : Bool;
 
-    public function new(t: Table, has_properties: Bool = true) {
+    public function new(t: Table, has_properties: Bool = true,
+                        may_be_nested : Bool = false) {
         this.t = t;
         rowChange();
         colChange();
         this.has_properties = has_properties;
+        this.may_be_nested = may_be_nested;
         this.metadata = null;
         this.keys = null;
         row_active = false;
@@ -211,6 +214,18 @@ class SimpleMeta implements Meta {
 
     public function getRowStream() : RowStream {
         return new TableStream(t);
+    }
+
+    public function isNested() : Bool {
+        return may_be_nested;
+    }
+
+    public function isSql() : Bool {
+        return false;
+    }
+
+    public function getName() : String {
+        return null;
     }
 }
 

--- a/coopy/SimpleView.hx
+++ b/coopy/SimpleView.hx
@@ -63,5 +63,17 @@ class SimpleView implements View {
         return Std.is(h,haxe.ds.StringMap);
 #end
     }
+
+    public function isTable(t : Dynamic) : Bool {
+        return Std.is(t,Table);
+    }
+
+    public function getTable(t : Dynamic) : Table {
+        return cast t;
+    }
+
+    public function wrapTable(t : Table) : Dynamic {
+        return t;
+    }
 }
 

--- a/coopy/SqlTable.hx
+++ b/coopy/SqlTable.hx
@@ -232,6 +232,14 @@ class SqlTable implements Table implements Meta implements RowStream {
         return this;
     }
 
+    public function isNested() : Bool {
+        return false;
+    }
+
+    public function isSql() : Bool {
+        return true;
+    }
+
     public function fetchRow() : Map<String, Dynamic> {
         if (db.read()) {
             var row = new Map<String,Dynamic>();
@@ -247,6 +255,10 @@ class SqlTable implements Table implements Meta implements RowStream {
     public function fetchColumns() : Array<String> {
         getColumns();
         return columnNames;
+    }
+
+    public function getName() : String {
+        return name.toString();
     }
 }
 

--- a/coopy/SqlTables.hx
+++ b/coopy/SqlTables.hx
@@ -1,0 +1,102 @@
+// -*- mode:java; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+#if !TOPLEVEL
+package coopy;
+#end
+
+@:expose
+class SqlTables implements Table {
+    private var db: SqlDatabase;
+    private var t: Table;
+    private var flags: CompareFlags;
+
+    public function new(db: SqlDatabase, flags: CompareFlags) {
+        this.db = db;
+        var helper = this.db.getHelper();
+        var names = helper.getTableNames(db);
+        var allowed : Map<String,Bool> = null;
+        var count : Int = names.length;
+        if (flags.tables!=null) {
+            allowed = new Map<String,Bool>();
+            for (name in flags.tables) {
+                allowed.set(name,true);
+            }
+            count = 0;
+            for (name in names) {
+                if (allowed.exists(name)) {
+                    count++;
+                }
+            }
+        }
+        t = new SimpleTable(2,count+1);
+        t.setCell(0,0,"name");
+        t.setCell(1,0,"table");
+        var v = t.getCellView();
+        var at = 1;
+        for (name in names) {
+            if (allowed!=null) {
+                if (!allowed.exists(name)) continue;
+            }
+            t.setCell(0,at,name);
+            t.setCell(1,at,v.wrapTable(new SqlTable(db, new SqlTableName(name))));
+            at++;
+        }
+    }
+
+    public var height(get_height,never) : Int;
+    public var width(get_width,never) : Int;
+
+    public function getCell(x: Int, y: Int) : Dynamic {
+        return t.getCell(x,y);
+    }
+
+    public function setCell(x: Int, y: Int, c : Dynamic) : Void {
+    }
+
+    public function getCellView() : View {
+        return t.getCellView();
+    }
+
+    public function isResizable() : Bool {
+        return false;
+    }
+
+    public function resize(w: Int, h: Int) : Bool {
+        return false;
+    }
+
+    public function clear() : Void {
+    }
+
+    public function insertOrDeleteRows(fate: Array<Int>, hfate: Int) : Bool {
+        return false;
+    }
+
+    public function insertOrDeleteColumns(fate: Array<Int>, wfate: Int) : Bool {
+        return false;
+    }
+
+    public function trimBlank() : Bool {
+        return false;
+    }
+
+    public function get_width() : Int {
+        return t.width;
+    }
+
+    public function get_height() : Int {
+        return t.height;
+    }
+
+    public function getData() : Dynamic {
+        return null;
+    }
+
+    public function clone() : Table {
+        return null;
+    }
+
+    public function getMeta() : Meta {
+        return new SimpleMeta(this,true,true);
+    }
+}

--- a/coopy/TableComparisonState.hx
+++ b/coopy/TableComparisonState.hx
@@ -81,6 +81,14 @@ class TableComparisonState {
      */
     public var compare_flags : CompareFlags;
 
+    public var p_meta : Meta;
+    public var a_meta : Meta;
+    public var b_meta : Meta;
+
+    public var alignment : Alignment;
+    public var children : Map<String,TableComparisonState>;
+    public var child_order : Array<String>;
+
     public function new() : Void {
         reset();
     }
@@ -99,5 +107,14 @@ class TableComparisonState {
         has_same_columns = false;
         has_same_columns_known = false;
         compare_flags = null;
+        alignment = null;
+        children = null;
+        child_order = null;
+    }
+
+    public function getMeta() : Void {
+        if (p!=null && p_meta==null) p_meta = p.getMeta();
+        if (a!=null && a_meta==null) a_meta = a.getMeta();
+        if (b!=null && b_meta==null) b_meta = b.getMeta();
     }
 }

--- a/coopy/Tables.hx
+++ b/coopy/Tables.hx
@@ -1,0 +1,46 @@
+// -*- mode:java; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+#if !TOPLEVEL
+package coopy;
+#end
+
+@:expose
+class Tables {
+    private var template : Table;
+    private var tables : Map<String, Table>;
+    private var table_order : Array<String>;
+
+    public var alignment: Alignment;
+
+    public function new(template : Table) {
+        this.template = template;
+        this.tables = new Map<String,Table>();
+        this.table_order = new Array<String>();
+    }
+
+    public function add(name : String) : Table {
+        var t = template.clone();
+        tables.set(name,t);
+        table_order.push(name);
+        return t;
+    }
+
+    public function getOrder() : Array<String> {
+        return table_order;
+    }
+
+    public function get(name : String) : Table {
+        return tables.get(name);
+    }
+
+    public function one() : Table {
+        return tables.get(table_order[0]);
+    }
+
+    public function hasInsDel() {
+        if (alignment==null) return false;
+        if (alignment.has_addition) return true;
+        if (alignment.has_removal) return true;
+        return false;
+    }
+}

--- a/coopy/View.hx
+++ b/coopy/View.hx
@@ -86,4 +86,10 @@ interface View {
      *
      */
     function hashGet(h: Dynamic, str: String) : Dynamic;
+
+    function isTable(t : Dynamic) : Bool;
+
+    function getTable(t : Dynamic) : Table;
+
+    function wrapTable(t : Table) : Dynamic;
 }

--- a/env/php/PhpCellView.class.php
+++ b/env/php/PhpCellView.class.php
@@ -13,4 +13,7 @@ class coopy_PhpCellView implements coopy_View {
   public function hashSet(&$d,$k,$v) { $d[$k] = $v; }
   public function hashGet($d,$k) { return $d[$k]; }
   public function hashExists($d,$k) { return array_key_exists($k,$d); }
+  public function isTable($t) { return false; }
+  public function getTable($t) { return false; }
+  public function wrapTable($t) { return false; }
 }


### PR DESCRIPTION
So far sqlite diffs have been restricted to a single table. This removes that limitation, providing useful diffs for multi-table changes, addition of tables, and removal of tables.