### PR TITLE
parse csv with rows of unexpected length in saner way

### DIFF
--- a/coopy/Csv.hx
+++ b/coopy/Csv.hx
@@ -127,8 +127,19 @@ class Csv {
                 tab.resize(w,h);
             }
             if (at>=w) {
-                w = at+1;
-                tab.resize(w,h);
+                if (yat>0) {
+                    if (cell != "" && cell != null) {
+                        var context : String = "";
+                        for (i in 0...w) {
+                            if (i>0) context += ",";
+                            context += tab.getCell(i,yat);
+                        }
+                        trace("Ignored overflowing row " + yat + " with cell '" + cell + "' after: " + context);
+                    }
+                } else {
+                    w = at+1;
+                    tab.resize(w,h);
+                }
             }
             tab.setCell(at,h-1,cell);
             at++;

--- a/harness/BasicTest.hx
+++ b/harness/BasicTest.hx
@@ -129,4 +129,13 @@ class BasicTest extends haxe.unit.TestCase {
         coopy.Coopy.patch(table2b,out);
         assertTrue(coopy.SimpleTable.tableIsSimilar(table4,table2b));
     }
+
+    public function testStraySpaceInCsv() {
+        var csv = new coopy.Csv();
+        var tab = csv.makeTable("id,color\n" +
+                                "15,red\n" +
+                                "13,mauve,,,\n" +
+                                "2,green\n");
+        assertEquals(tab.width,2);
+    }
 }


### PR DESCRIPTION
Prior to this, a CSV file with a row that had more cells
than others would result in silently mis-reading the entire
table.  With this change, such cells are ignored, and the
user is warned (if the cells are non-blank).

Thanks @paulsaurels for reporting a case of this.