### PR TITLE
strip BOM marker when loading utf8 text

### DIFF
--- a/env/js/util.js
+++ b/env/js/util.js
@@ -12,11 +12,17 @@ if (typeof exports != "undefined") {
     var tty = null;
     
     tio.getContent = function(name) {
+        var txt = "";
 	if (name=="-") {
 	    // only works on Linux, all other solutions seem broken
-	    return fs.readFileSync('/dev/stdin',"utf8");
+	    txt = fs.readFileSync('/dev/stdin',"utf8");
+	} else {
+	    txt = fs.readFileSync(name,"utf8");
+        }
+        if (txt.charCodeAt(0) === 0xFEFF) {
+	    return txt.slice(1);
 	}
-	return fs.readFileSync(name,"utf8");
+        return txt;
     }
     
     tio.saveContent = function(name,txt) {


### PR DESCRIPTION
See https://github.com/nodejs/node-v0.x-archive/issues/1918

Thanks @paulsaurels for reporting a case of this.