### PR TITLE
teach daff to diff workbooks expressed in json

### DIFF
--- a/coopy/DiffRender.hx
+++ b/coopy/DiffRender.hx
@@ -367,6 +367,23 @@ class DiffRender {
         return this;
     }
 
+    public function renderTables(tabs: Tables) : DiffRender {
+        var order : Array<String> = tabs.getOrder();
+        if (order.length==0 || tabs.hasInsDel()) {
+            render(tabs.one());
+        }
+        for (i in 1...order.length) {
+            var name = order[i];
+            var tab : Table = tabs.get(name);
+            if (tab.height<=1) continue;
+            insert("<h3>");
+            insert(name);
+            insert("</h3>\n");
+            render(tab);
+        }
+        return this;
+    }
+
     /**
      *
      * @return sample css for the generated html

--- a/coopy/JsonTable.hx
+++ b/coopy/JsonTable.hx
@@ -1,0 +1,148 @@
+// -*- mode:java; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+#if !TOPLEVEL
+package coopy;
+#end
+
+class JsonTable implements Table implements Meta {
+    private var w : Int;
+    private var h : Int;
+    private var columns : Array<String>;
+    private var rows : Array<Map<String,Dynamic>>;
+    private var data : Dynamic;
+    private var idx2col : Map<Int,String>;
+    private var name : String;
+
+    public function new(data: Dynamic, name: String) : Void {
+        this.data = data;
+        this.columns = cast Reflect.field(data, "columns");
+        this.rows = cast Reflect.field(data, "rows");
+        this.w = this.columns.length;
+        this.h = this.rows.length;
+        idx2col = new Map<Int,String>();
+        for (idx in 0...this.columns.length) {
+            idx2col[idx] = this.columns[idx];
+        }
+        this.name = name;
+    }
+
+    public function getTable() : Table {
+        return this;
+    }
+
+    public var height(get_height,never) : Int;
+    public var width(get_width,never) : Int;
+
+    public function get_width() : Int {
+        return w;
+    }
+
+    public function get_height() : Int {
+        return h+1;
+    }
+
+    public function getCell(x: Int, y: Int) : Dynamic {
+        if (y==0) {
+            return idx2col[x];
+        }
+        return Reflect.field(rows[y-1], idx2col[x]);
+    }
+
+    public function setCell(x: Int, y: Int, c: Dynamic) : Void {
+        trace("JsonTable is read-only");
+    }
+
+    public function toString() : String {
+        return "";
+    }
+
+    public function getCellView() : View {
+        return new SimpleView();
+    }
+
+    public function isResizable() : Bool {
+        return false;
+    }
+
+    public function resize(w: Int, h: Int) : Bool {
+        return false;
+    }
+
+    public function clear() : Void {
+    }
+
+    public function insertOrDeleteRows(fate: Array<Int>, hfate: Int) : Bool {
+        return false;
+    }
+
+    public function insertOrDeleteColumns(fate: Array<Int>, wfate: Int) : Bool {
+        return false;
+    }
+
+    public function trimBlank() : Bool {
+        return false;
+    }
+
+    public function getData() : Dynamic {
+        return null;
+    }
+
+    public function clone() : Table {
+        return null;
+    }
+
+    public function setMeta(meta: Meta) {
+    }
+
+    public function getMeta() : Meta {
+        return this;
+    }
+
+    public function create() : Table {
+        return new JsonTable(null, null);
+    }
+
+    public function alterColumns(columns : Array<ColumnChange>) : Bool {
+        return false;
+    }
+
+    public function changeRow(rc: RowChange) : Bool {
+        return false;
+    }
+
+    public function applyFlags(flags: CompareFlags) : Bool {
+        return false;
+    }
+
+    public function asTable() : Table {
+        return null;
+    }
+
+    public function cloneMeta(table: Table = null) : Meta {
+        return null;
+    }
+
+    public function useForColumnChanges() : Bool {
+        return false;
+    }
+
+    public function useForRowChanges() : Bool {
+        return false;
+    }
+
+    public function getRowStream() : RowStream {
+        return null;
+    }
+
+    public function isNested() : Bool {
+        return false;
+    }
+
+    public function isSql() : Bool {
+        return false;
+    }
+
+    public function getName() : String {
+        return name;
+    }
+}

--- a/coopy/JsonTables.hx
+++ b/coopy/JsonTables.hx
@@ -1,0 +1,130 @@
+// -*- mode:java; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+#if !TOPLEVEL
+package coopy;
+#end
+
+/**
+ *
+ * Experimental wrapper for reading tables expressed as json in following
+ * format:
+ *
+ * {
+ *   "names": ["sheet1", "sheet2"],
+ *   "tables": {
+ *     "sheet1": {
+ *        "columns": ["col1", "col2", "col3"],
+ *        "rows": [
+ *            { "col1": 42, "col2": "x", "col3": null },
+ *            { "col1": 24, "col2": "y", "col3": null },
+ *            ...
+ *        ]
+ *     },
+ *     "sheet2": {
+ *        ...
+ *     }
+ *   }
+ * }
+ *
+ *
+ */
+class JsonTables implements Table {
+    private var db: Dynamic;
+    private var t: Table;
+    private var flags: CompareFlags;
+
+    public function new(json: Dynamic, flags: CompareFlags) {
+        this.db = json;
+        var names : Array<String> = Reflect.field(json, "names");
+        var allowed : Map<String,Bool> = null;
+        var count : Int = names.length;
+        if (flags.tables!=null) {
+            allowed = new Map<String,Bool>();
+            for (name in flags.tables) {
+                allowed.set(name,true);
+            }
+            count = 0;
+            for (name in names) {
+                if (allowed.exists(name)) {
+                    count++;
+                }
+            }
+        }
+        t = new SimpleTable(2,count+1);
+        t.setCell(0,0,"name");
+        t.setCell(1,0,"table");
+        var v = t.getCellView();
+        var at = 1;
+        for (name in names) {
+            if (allowed!=null) {
+                if (!allowed.exists(name)) continue;
+            }
+            t.setCell(0,at,name);
+            var tab = Reflect.field(db, "tables");
+            tab = Reflect.field(tab, name);
+            t.setCell(1,at,v.wrapTable(new JsonTable(tab, name)));
+            at++;
+        }
+    }
+
+    public var height(get_height,never) : Int;
+    public var width(get_width,never) : Int;
+
+    public function getCell(x: Int, y: Int) : Dynamic {
+        return t.getCell(x,y);
+    }
+
+    public function setCell(x: Int, y: Int, c : Dynamic) : Void {
+    }
+
+    public function getCellView() : View {
+        return t.getCellView();
+    }
+
+    public function isResizable() : Bool {
+        return false;
+    }
+
+    public function resize(w: Int, h: Int) : Bool {
+        return false;
+    }
+
+    public function clear() : Void {
+    }
+
+    public function insertOrDeleteRows(fate: Array<Int>, hfate: Int) : Bool {
+        return false;
+    }
+
+    public function insertOrDeleteColumns(fate: Array<Int>, wfate: Int) : Bool {
+        return false;
+    }
+
+    public function trimBlank() : Bool {
+        return false;
+    }
+
+    public function get_width() : Int {
+        return t.width;
+    }
+
+    public function get_height() : Int {
+        return t.height;
+    }
+
+    public function getData() : Dynamic {
+        return null;
+    }
+
+    public function clone() : Table {
+        return null;
+    }
+
+    public function getMeta() : Meta {
+        return new SimpleMeta(this,true,true);
+    }
+
+    public function create() : Table {
+        return new JsonTables(null,null);
+    }
+}


### PR DESCRIPTION
This adds a basic wrapper for diffing multiple tables
expressed as json in the following form:

```js
{
  "names": ["sheet1", "sheet2"],
  "tables": {
    "sheet1": {
       "columns": ["col1", "col2", "col3"],
       "rows": [
           { "col1": 42, "col2": "x", "col3": null },
           { "col1": 24, "col2": "y", "col3": null },
           ...
       ]
    },
    "sheet2": {
       ...
    }
  }
}
```