### PR TITLE
add flag for ignoring case during comparison

### DIFF
--- a/coopy/CompareFlags.hx
+++ b/coopy/CompareFlags.hx
@@ -195,6 +195,13 @@ class CompareFlags {
      */
     public var ignore_whitespace : Bool;
 
+    /**
+     *
+     * Should case be omitted from comparisons.  Defaults to false.
+     *
+     */
+    public var ignore_case : Bool;
+
     public function new() {
         ordered = true;
         show_unchanged = false;
@@ -216,6 +223,7 @@ class CompareFlags {
         parent = null;
         count_like_a_spreadsheet = true;
         ignore_whitespace = false;
+        ignore_case = false;
     }
 
     /**

--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -742,6 +742,11 @@ class Coopy {
                     flags.ignore_whitespace = true;
                     args.splice(i,1);
                     break;
+                } else if (tag=="-i" || tag=="--ignore-case") {
+                    more = true;
+                    flags.ignore_case = true;
+                    args.splice(i,1);
+                    break;
                 } else if (tag=="--padding") {
                     more = true;
                     flags.padding_strategy = args[i+1];
@@ -819,6 +824,7 @@ class Coopy {
             io.writeStderr("     --table NAME:  compare the named table, used with SQL sources\n");
             io.writeStderr("     --unordered:   assume row order is meaningless (default for json formats)\n");
             io.writeStderr("     -w / --ignore-whitespace: ignore changes in leading/trailing whitespace\n");
+            io.writeStderr("     -i / --ignore-case: ignore differences in case\n");
             io.writeStderr("\n");
             io.writeStderr("  daff render [--output OUTPUT.html] [--css CSS.css] [--fragment] [--plain] diff.csv\n");
             io.writeStderr("     --css CSS.css: generate a suitable css file to go with the html\n");

--- a/coopy/Index.hx
+++ b/coopy/Index.hx
@@ -16,6 +16,7 @@ class Index {
     private var indexed_table : Table;
     private var hdr : Int;
     private var ignore_whitespace : Bool;
+    private var ignore_case : Bool;
 
     public function new(flags : CompareFlags) : Void {
         items = new Map<String,IndexItem>();
@@ -25,8 +26,10 @@ class Index {
         height = 0;
         hdr = 0;
         ignore_whitespace = false;
+        ignore_case = false;
         if (flags!=null) {
             ignore_whitespace = flags.ignore_whitespace;
+            ignore_case = flags.ignore_case;
         }
     }
  
@@ -68,6 +71,9 @@ class Index {
             if (ignore_whitespace) {
                 txt = StringTools.trim(txt);
             }
+            if (ignore_case) {
+                txt = txt.toLowerCase();
+            }
             if (k>0) wide += " // ";
             if (txt==null || txt=="" || txt=="null" || txt=="undefined") continue;
             wide += txt;
@@ -81,6 +87,9 @@ class Index {
             var txt : String = row.getRowString(cols[k]);
             if (ignore_whitespace) {
                 txt = StringTools.trim(txt);
+            }
+            if (ignore_case) {
+                txt = txt.toLowerCase();
             }
             if (k>0) wide += " // ";
             if (txt==null || txt=="" || txt=="null" || txt=="undefined") continue;

--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -415,7 +415,7 @@ class TableDiff {
                 if (p.height>=rp_header && b.height>=rb_header) {
                     var pp : Dynamic = p.getCell(cunit.lp(),rp_header);
                     var bb : Dynamic = b.getCell(cunit.r,rb_header);
-                    if (!v.equals(pp,bb)) {
+                    if (!isEqual(v,pp,bb)) {
                         have_schema = true;
                         act = "(";
                         act += v.toString(pp);
@@ -646,9 +646,24 @@ class TableDiff {
         }
     }
 
-    private function isEqual(v: View, aa: Dynamic, bb: Dynamic) {
+    private function normalizeString(v: View, str: Dynamic) : String {
+        if (str==null) return str;
+        if (!(flags.ignore_whitespace||flags.ignore_case)) {
+            return str;
+        }
+        var txt = v.toString(str);
         if (flags.ignore_whitespace) {
-            return StringTools.trim(v.toString(aa)) == StringTools.trim(v.toString(bb));
+            txt = StringTools.trim(txt);
+        }
+        if (flags.ignore_case) {
+            txt = txt.toLowerCase();
+        }
+        return txt;
+    }
+
+    private function isEqual(v: View, aa: Dynamic, bb: Dynamic) : Bool {
+        if (flags.ignore_whitespace || flags.ignore_case) {
+            return normalizeString(v,aa) == normalizeString(v,bb);
         }
         return v.equals(aa,bb);
     }

--- a/harness/EqualityTest.hx
+++ b/harness/EqualityTest.hx
@@ -2,10 +2,11 @@
 
 package harness;
 
-class WhiteSpaceTest extends haxe.unit.TestCase {
+class EqualityTest extends haxe.unit.TestCase {
     var data1 : Array<Array<Dynamic>>;
     var data2 : Array<Array<Dynamic>>;
     var data3 : Array<Array<Dynamic>>;
+    var data4 : Array<Array<Dynamic>>;
 
     override public function setup() {
         data1 = [['Country','Capital'],
@@ -20,9 +21,13 @@ class WhiteSpaceTest extends haxe.unit.TestCase {
                  ['Ireland','  Dublin'],
                  ['France',15],
                  ['Spain','  Madrid  ']];
+        data4 = [['COUNTRY','Capital'],
+                 ['IRELAND','DUBlin'],
+                 ['France',15],
+                 ['SPAIN','BARCELONA']];
     }
 
-    public function testBasic(){
+    public function testWhiteSpace(){
         var table1 = Native.table(data1);
         var table2 = Native.table(data2);
         var flags = new coopy.CompareFlags();
@@ -35,5 +40,18 @@ class WhiteSpaceTest extends haxe.unit.TestCase {
         var table3 = Native.table(data3);
         o = coopy.Coopy.diff(table1,table3,flags);
         assertEquals(2,o.height);
+    }
+
+    public function testCase(){
+        var table1 = Native.table(data1);
+        var table4 = Native.table(data4);
+        var flags = new coopy.CompareFlags();
+        flags.unchanged_context = 0;
+        var o = coopy.Coopy.diff(table1,table4,flags);
+        assertEquals(6,o.height);
+        flags.ignore_case = true;
+        flags.ignore_whitespace = true;
+        o = coopy.Coopy.diff(table1,table4,flags);
+        assertEquals(1,o.height);
     }
 }

--- a/harness/Main.hx
+++ b/harness/Main.hx
@@ -19,7 +19,7 @@ class Main {
                      new JsonTest(), 
                      new MetaTest(),
                      new PatchTest(),
-                     new WhiteSpaceTest()
+                     new EqualityTest()
                      ];
 
         if (Native.hasSqlite()) {


### PR DESCRIPTION
This adds a `-i` / `--ignore-case` flag that works in a similar way to `diff -i`, with cells that differ only in case being treated as identical.

Case is a complex subject so depending on your language your mileage may vary.

Motivated by https://twitter.com/thmchx/status/661951143967383552
