### PR TITLE
use the ppa provided by haxe foundation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 before_install:
   - sudo apt-get update
   - if ! $USE_PAULFITZ; then sudo apt-get install python-software-properties -y; fi
-  - if ! $USE_PAULFITZ; then sudo add-apt-repository ppa:eyecreate/haxe -y; fi
+  - if ! $USE_PAULFITZ; then sudo add-apt-repository ppa:haxe/releases -y; fi
   - if ! $USE_PAULFITZ; then sudo apt-get update; fi
 
 install:


### PR DESCRIPTION
The official ppa is guaranteed to provide updated release of Haxe. It currently provides Haxe 3.2.1.
Eyecreate's one provides Haxe 3.2.0.

daff is an excellent use of Haxe. 
Keep it up! : )