### PR TITLE
fix html-format diffs of nested tables

### DIFF
--- a/coopy/JsonTable.hx
+++ b/coopy/JsonTable.hx
@@ -99,7 +99,7 @@ class JsonTable implements Table implements Meta {
     }
 
     public function create() : Table {
-        return new JsonTable(null, null);
+        return null;
     }
 
     public function alterColumns(columns : Array<ColumnChange>) : Bool {

--- a/coopy/JsonTables.hx
+++ b/coopy/JsonTables.hx
@@ -38,7 +38,7 @@ class JsonTables implements Table {
         var names : Array<String> = Reflect.field(json, "names");
         var allowed : Map<String,Bool> = null;
         var count : Int = names.length;
-        if (flags.tables!=null) {
+        if (flags!=null && flags.tables!=null) {
             allowed = new Map<String,Bool>();
             for (name in flags.tables) {
                 allowed.set(name,true);
@@ -125,6 +125,6 @@ class JsonTables implements Table {
     }
 
     public function create() : Table {
-        return new JsonTables(null,null);
+        return null;
     }
 }

--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -927,6 +927,10 @@ class TableDiff {
      *
      */
     public function hilite(output: Table) : Bool { 
+        return hiliteSingle(output);
+    }
+
+    private function hiliteSingle(output: Table) : Bool { 
         if (!output.isResizable()) return false;
         if (builder==null) {
             if (flags.allow_nested_cells) {
@@ -1059,7 +1063,7 @@ class TableDiff {
     // multi-table version
     public function hiliteWithNesting(output: Tables) : Bool {
         var base = output.add("base");
-        var result = hilite(base);
+        var result = hiliteSingle(base);
         if (!result) return false;
         if (align.comp==null) return true;
         var order = align.comp.child_order;
@@ -1074,7 +1078,7 @@ class TableDiff {
             }
             var td = new TableDiff(alignment,flags);
             var child_output = output.add(name);
-            result = result && td.hilite(child_output);
+            result = result && td.hiliteSingle(child_output);
         }
         return result;
     }
@@ -1099,6 +1103,11 @@ class TableDiff {
 
     public function isNested() : Bool {
         return nesting_present;
+    }
+
+    public function getComparisonState() : TableComparisonState {
+        if (align==null) return null;
+        return align.comp;
     }
 }
 


### PR DESCRIPTION
This is sufficient to make diffs of multi-table json or sqlite sources readable when output in html format.