### PR TITLE
make ansi output available to library match command-line utility

### DIFF
--- a/coopy/CompareFlags.hx
+++ b/coopy/CompareFlags.hx
@@ -202,6 +202,15 @@ class CompareFlags {
      */
     public var ignore_case : Bool;
 
+    /**
+     *
+     * Format to use for terminal output.  "plain" for plain text,
+     * "ansi", for ansi color codes, null to autodetect.  Defaults to
+     * autodetect.
+     *
+     */
+    public var terminal_format : String;
+
     public function new() {
         ordered = true;
         show_unchanged = false;
@@ -224,6 +233,7 @@ class CompareFlags {
         count_like_a_spreadsheet = true;
         ignore_whitespace = false;
         ignore_case = false;
+        terminal_format = null;
     }
 
     /**

--- a/coopy/TableIO.hx
+++ b/coopy/TableIO.hx
@@ -16,6 +16,20 @@ class TableIO {
 
     /**
      *
+     * Check if system services are in fact implemented.  For some
+     * platforms, an external implementation needs to be passed in.
+     *
+     */
+    public function valid() : Bool {
+#if coopyhx_util
+        return true;
+#else
+        return false;
+#end
+    }
+
+    /**
+     *
      * Read a file.
      * @param name the name of the file to read
      * @return the content of the file

--- a/env/js/util.js
+++ b/env/js/util.js
@@ -11,6 +11,10 @@ if (typeof exports != "undefined") {
     var sqlite3 = null;
     var tty = null;
     
+    tio.valid = function() {
+        return true;
+    }
+
     tio.getContent = function(name) {
         var txt = "";
 	if (name=="-") {


### PR DESCRIPTION
When using daff as a library, the command for generating terminal
output didn't cope well with multi-table diffs.  This commit
brings this command into line with the output of the command-line
daff utility.