### PR TITLE
Always call nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_install:
   - if ! $USE_PAULFITZ; then sudo apt-get install python-software-properties -y; fi
   - if ! $USE_PAULFITZ; then sudo add-apt-repository ppa:haxe/releases -y; fi
   - if ! $USE_PAULFITZ; then sudo apt-get update; fi
+  - sudo apt-get --purge remove node
+  - sudo apt-get --purge remove nodejs
+  - sudo apt-get install nodejs
 
 install:
   - sudo apt-get install time php5 sqlite3 -y
@@ -28,7 +31,6 @@ install:
   - if ! $USE_PAULFITZ; then haxelib install hxcs; fi
   - npm install
   - if $USE_PAULFITZ; then hg -y clone https://bitbucket.org/eshuy/lib3to2; cd lib3to2; sudo python3 ./setup.py install; cd ..; fi
-  - sudo apt-get install nodejs
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   - if ! $USE_PAULFITZ; then haxelib install hxcs; fi
   - npm install
   - if $USE_PAULFITZ; then hg -y clone https://bitbucket.org/eshuy/lib3to2; cd lib3to2; sudo python3 ./setup.py install; cd ..; fi
+  - sudo apt-get install nodejs
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ ntest: ntest_js ntest_rb ntest_py ntest_php ntest_java
 
 ntest_js: js
 	haxe -js ntest.js -D haxeJSON -main harness.Main
-	NODE_PATH=$$PWD/lib node ntest.js
+	NODE_PATH=$$PWD/lib nodejs ntest.js
 
 ntest_py: py
 	./scripts/run_tests.sh "" py
@@ -248,7 +248,7 @@ ntest_rb: rb
 
 perf_js:
 	haxe -D enbiggen -js ntest.js -main harness.Main
-	NODE_PATH=$$PWD/lib node ntest.js
+	NODE_PATH=$$PWD/lib nodejs ntest.js
 
 perf_php:
 	haxe -D enbiggen -php ntest_php_dir -main harness.Main

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -12,7 +12,7 @@ for f in `ls -1 *.$EXT | grep "$1"`; do
     echo "=============================================================================="
     echo "== $f"
     if [[ "$EXT" = "js" ]]; then
-	NODE_PATH=$BASE/lib:$BASE/scripts node ./$f || exit 1
+	NODE_PATH=$BASE/lib:$BASE/scripts nodejs ./$f || exit 1
     elif [[ "$EXT" = "py" ]]; then
 	PYTHONPATH=$PYTHONPATH:$BASE/python_bin python3 ./$f || exit 1
     elif [[ "$EXT" = "rb" ]]; then


### PR DESCRIPTION
Using nodejs instead of node to avoid the name-clash with an Amateur Radio thing called `ax25-node` which is also aliased `node`, see issue #60 for details
