### PR TITLE
don't clobber html output, fixes #66

### DIFF
--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -303,6 +303,7 @@ class Coopy {
 
     private function saveTable(name: String, t: Table, render: TerminalDiffRender = null) : Bool {
         var txt = encodeTable(name, t, render);
+        if (txt == null) return true;
         return saveText(name,txt);
     }
 
@@ -323,6 +324,7 @@ class Coopy {
                 txt = new Ndjson(t).render();
             } else if (format_preference=="html"||format_preference=="www") {
                 renderTable(name,t);
+                return null;
                 // cannot handle multi-table output yet
             } else if (format_preference=="sqlite") {
                 io.writeStderr("! Cannot yet output to sqlite, aborting\n");

--- a/test/test_file_types.js
+++ b/test/test_file_types.js
@@ -3,21 +3,26 @@ var tmp = require('tmp');
 var assert = require('assert');
 var daff = require('daff');
 
-tmp.tmpName({ template: '/tmp/tmp-XXXXXX.tsv' },function(err, tsv1) {
-    tmp.tmpName({ template: '/tmp/tmp-XXXXXX.csv' },function(err, csv1) {
-	tmp.tmpName({ template: '/tmp/tmp-XXXXXX.csv' },function(err, csv2) {
-	    if (err) throw err;
-	    assert(0==daff.cmd(["diff","data/bridges.csv","data/broken_bridges.csv","--output",tsv1]));
-	    assert(0==daff.cmd(["diff","data/bridges.csv","data/broken_bridges.csv","--output",csv1]));
-	    assert(0==daff.cmd(["copy",tsv1,csv2]));
-	    assert.notEqual(fs.readFileSync(tsv1,"utf-8"),fs.readFileSync(csv1,"utf-8"));
-	    assert.equal(fs.readFileSync(csv1,"utf-8"),fs.readFileSync(csv2,"utf-8"));
-	    assert(0==daff.cmd(["diff","data/bridges.csv","data/broken_bridges.csv","--output-format","csv","--output",tsv1]));
-	    assert.equal(fs.readFileSync(tsv1,"utf-8"),fs.readFileSync(csv1,"utf-8"));
-	    fs.unlinkSync(tsv1);
-	    fs.unlinkSync(csv1);
-	    fs.unlinkSync(csv2);
-	});
+tmp.tmpName({ template: '/tmp/tmp-XXXXXX.html' },function(err, html1) {
+    tmp.tmpName({ template: '/tmp/tmp-XXXXXX.tsv' },function(err, tsv1) {
+        tmp.tmpName({ template: '/tmp/tmp-XXXXXX.csv' },function(err, csv1) {
+	    tmp.tmpName({ template: '/tmp/tmp-XXXXXX.csv' },function(err, csv2) {
+	        if (err) throw err;
+	        assert(0==daff.cmd(["diff","data/bridges.csv","data/broken_bridges.csv","--output",tsv1]));
+	        assert(0==daff.cmd(["diff","data/bridges.csv","data/broken_bridges.csv","--output",csv1]));
+	        assert(0==daff.cmd(["copy",tsv1,csv2]));
+	        assert.notEqual(fs.readFileSync(tsv1,"utf-8"),fs.readFileSync(csv1,"utf-8"));
+	        assert.equal(fs.readFileSync(csv1,"utf-8"),fs.readFileSync(csv2,"utf-8"));
+	        assert(0==daff.cmd(["diff","data/bridges.csv","data/broken_bridges.csv","--output-format","csv","--output",tsv1]));
+	        assert.equal(fs.readFileSync(tsv1,"utf-8"),fs.readFileSync(csv1,"utf-8"));
+	        assert(0==daff.cmd(["diff","data/bridges.csv","data/broken_bridges.csv","--output-format","html","--output",html1]));
+	        assert(fs.readFileSync(html1,"utf-8").indexOf("highlighter")>=0)
+	        fs.unlinkSync(tsv1);
+	        fs.unlinkSync(csv1);
+	        fs.unlinkSync(csv2);
+	        fs.unlinkSync(html1);
+	    });
+        });
     });
 });
 


### PR DESCRIPTION
HTML output was accidentally being overwritten with empty output. This adds a fix and a test so it doesn't happen again. Thanks @spaceman-cb for the heads up.