### PR TITLE
support --plain flag that suppresses use of utf8 glyphs

### DIFF
--- a/coopy/CompareFlags.hx
+++ b/coopy/CompareFlags.hx
@@ -211,6 +211,14 @@ class CompareFlags {
      */
     public var terminal_format : String;
 
+    /**
+     *
+     * Choose whether we can use utf8 characters for describing diff
+     * (specifically long arrow).  Defaults to true.
+     *
+     */
+    public var use_glyphs : Bool;
+
     public function new() {
         ordered = true;
         show_unchanged = false;
@@ -234,6 +242,7 @@ class CompareFlags {
         ignore_whitespace = false;
         ignore_case = false;
         terminal_format = null;
+        use_glyphs = true;
     }
 
     /**

--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -28,7 +28,6 @@ class Coopy {
     private var order_set : Bool;
     private var order_preference : Bool;
     private var io : TableIO;
-    private var pretty : Bool;
     private var strategy : String;
     private var css_output : String;
     private var fragment : Bool;
@@ -53,7 +52,6 @@ class Coopy {
         order_set = false;
         order_preference = false;
         strategy = null;
-        pretty = true;
         css_output = null;
         fragment = false;
         flags = null;
@@ -270,7 +268,7 @@ class Coopy {
 
     private function getRenderer() : DiffRender {
         var renderer : DiffRender = new DiffRender();
-        renderer.usePrettyArrows(pretty);
+        renderer.usePrettyArrows(flags.use_glyphs);
         return renderer;
     }
 
@@ -730,7 +728,7 @@ class Coopy {
                     break;
                 } else if (tag=="--plain") {
                     more = true;
-                    pretty = false;
+                    flags.use_glyphs = false;
                     args.splice(i,1);
                     break;
                 } else if (tag=="--all") {

--- a/coopy/TerminalDiffRender.hx
+++ b/coopy/TerminalDiffRender.hx
@@ -18,11 +18,13 @@ class TerminalDiffRender {
     private var v: View;
     private var align_columns : Bool;
     private var wide_columns : Bool;
+    private var use_glyphs : Bool;
     private var flags : CompareFlags;
 
     public function new(flags: CompareFlags = null) {
         align_columns = true;
         wide_columns = false;
+        use_glyphs = true;
         this.flags = flags;
         if (flags!=null) {
             if (flags.padding_strategy == "dense") {
@@ -31,6 +33,7 @@ class TerminalDiffRender {
             if (flags.padding_strategy == "sparse") {
                 wide_columns = true;
             }
+            use_glyphs = flags.use_glyphs;
         }
     }
 
@@ -118,18 +121,19 @@ class TerminalDiffRender {
                 if (code_tr!=null) code = code_tr;
             }
             if (code!=null) {
+                var separator = use_glyphs ? cell.pretty_separator : cell.separator;
                 if (cell.rvalue!=null) {
-                    val = codes["remove"] + cell.lvalue + codes["modify"] + cell.pretty_separator + codes["add"] + cell.rvalue + codes["done"];
+                    val = codes["remove"] + cell.lvalue + codes["modify"] + separator + codes["add"] + cell.rvalue + codes["done"];
                     if (cell.pvalue!=null) {
-                        val = codes["conflict"] + cell.pvalue + codes["modify"] + cell.pretty_separator + val;
+                        val = codes["conflict"] + cell.pvalue + codes["modify"] + separator + val;
                     }
                 } else {
-                    val = cell.pretty_value;
+                    val = use_glyphs ? cell.pretty_value : cell.value;
                     val = code + val + codes["done"];
                 }
             }
         } else {
-            val = cell.pretty_value;
+            val = use_glyphs ? cell.pretty_value : cell.value;
         }
         return csv.renderCell(v,val);
     }


### PR DESCRIPTION
Give a simple workaround for terminals where utf8 symbols in diff are causing problems, see #69.