### PR TITLE
Find daff at `exports` first in javascript

### DIFF
--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -1110,7 +1110,7 @@ class Coopy {
 
         // emergency! try to find and use native wrapper
 #if js
-        return untyped __js__("new (typeof window != 'undefined' ? window : exports).daff.TableView(data)");
+        return untyped __js__("new (typeof exports != 'undefined' ? exports : window).daff.TableView(data)");
 #elseif python
         python.Syntax.pythonCode("daff = __import__('daff')");
         return python.Syntax.pythonCode("daff.PythonTableView(data)");


### PR DESCRIPTION
This is related to the issue https://github.com/paulfitz/daff/issues/75.
