### PR TITLE
update python2 fixes for latest haxe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,8 @@ py2: py
 	sed -i 's/^\([ \t]*\)def next(/\1def __next__(self): return self.next()\n\n\1def next(/g' python_bin/daff.py
 	sed -i 's/from datetime import timezone/#from datetime import timezone/' python_bin/daff.py
 	sed -i 's/Date.EPOCH_UTC =/#Date.EPOCH_UTC =/' python_bin/daff.py
+	sed -i 's/from itertools import imap/import itertools; imap = itertools.imap if hasattr(itertools, "imap") else map/' python_bin/daff.py
+	sed -i 's/from itertools import ifilter/import itertools; ifilter = itertools.ifilter if hasattr(itertools, "ifilter") else filter/' python_bin/daff.py
 	cp scripts/python23.py python_bin/daff2.py
 	cat python_bin/daff.py | grep -v "from __future__" | grep -v "from __builtin__ import" | grep -v "import __builtin__ as" | grep -v '#!' >> python_bin/daff2.py
 	mv python_bin/daff2.py python_bin/daff.py

--- a/scripts/python23.py
+++ b/scripts/python23.py
@@ -39,6 +39,8 @@ else:
     hxunicode = str
     hxrange = range
     hxunichr = chr
+    unichr = chr
+    unicode = str
     def hxnext(x):
         return x.__next__()
     hx_cmp_to_key = functools.cmp_to_key


### PR DESCRIPTION
Haxe doesn't support python2, so we use the 3to2 utility to make haxe-generated python usable in python2.  Then we patch things up to make the same code still runnable in python3.  This code updates those patches for latest haxe.  This is getting a little creaky, and it will soon be preferable to publish a wheel
with multiple distinct code versions for different python flavors.

Motivated by #82.