### PR TITLE
add support for psv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,12 @@ py:
 	cat scripts/python_table_view.py >> python_bin/daff.py
 	cat env/py/export_functions.py >> python_bin/daff.py
 	cat env/py/sqlite_database.py >> python_bin/daff.py
-	echo "if __name__ == '__main__':" >> python_bin/daff.py
-	echo "\tCoopy.main()" >> python_bin/daff.py
 	sed -i 's/Sys.stdout().writeString(txt)/get_stdout().write(txt.encode("utf-8", "strict"))/' python_bin/daff.py # fix utf-8
 	sed -i 's/python_lib_Sys.stdout.buffer/get_stdout()/' python_bin/daff.py
+	echo 'def get_stdout():\n\treturn (python_lib_Sys.stdout.buffer if hasattr(python_lib_Sys.stdout,"buffer") else python_lib_Sys.stdout)' >> python_bin/daff.py
+	echo "if __name__ == '__main__':" >> python_bin/daff.py
+	echo "\tCoopy.main()" >> python_bin/daff.py
+
 	cp scripts/example.py python_bin/
 	@echo 'Output in python_bin, run "python3 python_bin/daff.py" for an example utility'
 	@echo 'or try "python3 python_bin/example.py" for an example of using daff as a library'
@@ -295,6 +297,7 @@ integration: js py
 setup_py: best_py
 	mkdir -p daff
 	cp python_bin/daff.py daff/__init__.py
+	echo "import daff\ndef main():\n\tdaff.Coopy.main()" > daff/__main__.py
 	echo "#!/usr/bin/env python" > daff.py
 	cat python_bin/daff.py >> daff.py # wasteful but robust
 

--- a/coopy/Csv.hx
+++ b/coopy/Csv.hx
@@ -79,11 +79,18 @@ class Csv {
         }
         var str: String = v.toString(d);
         var need_quote : Bool = false;
-        for (i in 0...str.length) {
-            var ch : String = str.charAt(i);
-            if (ch=='"'||ch=='\''||ch==delim||ch=='\r'||ch=='\n'||ch=='\t'||ch==' ') {
+        if (str.length > 0) {
+            if (str.charAt(0)==' '||str.charAt(str.length-1)==' ') {
                 need_quote = true;
-                break;
+            }
+        }
+        if (!need_quote) {
+            for (i in 0...str.length) {
+                var ch : String = str.charAt(i);
+                if (ch=='"'||ch=='\''||ch==delim||ch=='\r'||ch=='\n'||ch=='\t') {
+                    need_quote = true;
+                    break;
+                }
             }
         }
         

--- a/scripts/python23.py
+++ b/scripts/python23.py
@@ -1,3 +1,5 @@
+
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals, print_function
 try:
     import builtins
@@ -49,6 +51,3 @@ python_lib_Builtins = python_lib_Builtin = builtins
 String = builtins.str
 python_lib_Dict = builtins.dict
 python_lib_Set = builtins.set
-
-def get_stdout():
-    return (python_lib_Sys.stdout.buffer if hasattr(python_lib_Sys.stdout,"buffer") else python_lib_Sys.stdout)

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,44 @@
 #!/usr/bin/env python
 
 import os
-from distutils.core import setup
+from setuptools import setup
 from distutils.command.build_py import build_py
 from subprocess import call
 import json
 import os.path
 
+
 class my_build_py(build_py):
     def run(self):
         if os.path.isfile("Makefile"):
-            if call(["make","setup_py"])!=0:
+            if call(["make", "setup_py"]) != 0:
                 exit(1)
         build_py.run(self)
+
 
 def read(fname):
     with open(os.path.join(os.path.dirname(__file__), fname)) as f:
         return f.read()
 
+
 package = json.loads(read("package.json"))
 
+
 setup(
-    name = package['name'],
-    version = package['version'],
-    author = package['author']['name'],
-    author_email = package['author']['email'],
-    description = (package['description']),
-    license = package['license'],
-    keywords = "data diff patch",
-    url = package['url'],
+    name=package['name'],
+    version=package['version'],
+    author=package['author']['name'],
+    author_email=package['author']['email'],
+    description=(package['description']),
+    license=package['license'],
+    keywords="data diff patch",
+    url=package['url'],
     packages=['daff'],
-    scripts=['daff.py'],
+    entry_points={
+        "console_scripts": [
+            "daff=daff.__main__:main"
+        ]
+    },
     long_description=read('README.md'),
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This adds support for the psv format.  This is not easy in javascript due to the poop symbol lying on an astral plane, so for now I've focused on getting it right in python.

Now allow `daff foo.bar` to be used instead of `daff copy foo.bar`, for convenience.

Small cleanup to the python install rat's-nest.

See https://twitter.com/j4mie/status/804701143171497984