### PR TITLE
Python: Fix comparison to None when 'show_unchanged' is set

### DIFF
--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -1001,8 +1001,9 @@ class TableDiff {
                 publish = flags.show_unchanged;
                 var dummy : Bool = false;
                 if (out==1) {
-                    publish = active_row[i]>0;
-                    dummy = active_row[i]==3;
+                    var value: Null<Int> = active_row[i];
+                    publish = value!=null && value>0;
+                    dummy = value!=null && value==3;
                     if (dummy&&showed_dummy) continue;
                     if (!publish) continue;
                 }

--- a/harness/BasicTest.hx
+++ b/harness/BasicTest.hx
@@ -165,4 +165,13 @@ class BasicTest extends haxe.unit.TestCase {
                                 "2,green\n");
         assertEquals(tab.width,2);
     }
+
+    public function testShowChanged() {
+        var table1 = Native.table(data1);
+        var flags = new coopy.CompareFlags();
+        flags.show_unchanged = true;
+        var table = coopy.Coopy.diff(table1,table1,flags);
+        assertEquals(4,table.height);
+        assertEquals(3,table.width);
+    }
 }


### PR DESCRIPTION
I get an error when trying to compare two tables in Python with all rows shown:

```python
import daff

local = [[0], [1]]
remote = [[0], [2]]

flags = daff.CompareFlags()
flags.show_unchanged = True
table = daff.diff(local, remote, flags)
```

```
/home/sviatoslav/workspace/py34/bin/daff.py in hiliteSingle(self, output)
   8344                 dummy = False
   8345                 if (out == 1):
-> 8346                     self.publish = ((self.active_row[i] if i >= 0 and i < len(self.active_row) else None) > 0)
   8347                     dummy = ((self.active_row[i] if i >= 0 and i < len(self.active_row) else None) == 3)
   8348                     if (dummy and showed_dummy):

TypeError: unorderable types: NoneType() > int()
```

So I added a check if row is null.