### PR TITLE
add TableDiff.getSummary() for summary stats of diff

### DIFF
--- a/coopy/CompareTable.hx
+++ b/coopy/CompareTable.hx
@@ -401,6 +401,7 @@ class CompareTable {
         // we expect headers on row 0 - link them even if quite different.
         if (ha>0 && hb>0) {
             align.link(0,0);
+            align.headers(0,0);
         }
     }
 

--- a/coopy/DiffSummary.hx
+++ b/coopy/DiffSummary.hx
@@ -1,0 +1,33 @@
+// -*- mode:java; tab-width:4; c-basic-offset:4; indent-tabs-mode:nil -*-
+
+#if !TOPLEVEL
+package coopy;
+#end
+
+/**
+ *
+ * Summarize the changes in a diff of a pair of tables
+ *
+ */
+@:expose
+class DiffSummary {
+    public var row_deletes : Int;
+    public var row_inserts : Int;
+    public var row_updates : Int;
+    public var row_reorders : Int;
+
+    public var col_deletes : Int;
+    public var col_inserts : Int;
+    public var col_renames : Int;
+    public var col_reorders : Int;
+
+    public var row_count_initial_with_header : Int;
+    public var row_count_final_with_header : Int;
+    public var row_count_initial : Int;
+    public var row_count_final : Int;
+    public var col_count_initial : Int;
+    public var col_count_final : Int;
+
+    public function new() {
+    }
+}

--- a/coopy/DiffSummary.hx
+++ b/coopy/DiffSummary.hx
@@ -18,6 +18,7 @@ class DiffSummary {
 
     public var col_deletes : Int;
     public var col_inserts : Int;
+    public var col_updates : Int;
     public var col_renames : Int;
     public var col_reorders : Int;
 

--- a/coopy/Mover.hx
+++ b/coopy/Mover.hx
@@ -125,9 +125,9 @@ class Mover {
         var blks : Array<Int> = new Array<Int>();
         for (k in blk_len.keys()) { blks.push(k); }
         blks.sort(function(a,b) { 
-                var diff = blk_len.get(b)-blk_len.get(a); 
-                if (diff!=0) return diff;
-                return a-b;
+                var diff = blk_len.get(b)-blk_len.get(a);
+                if (diff==0) diff=a-b;
+                return diff;
             });
 
         var moved : Array<Int> = new Array<Int>();

--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -425,8 +425,10 @@ class TableDiff {
                 if (active_column!=null) {
                     if (allow_update) {
                         active_column[j] = 1;
-                        col_inserts++;
                     }
+                }
+                if (allow_update) {
+                    col_inserts++;
                 }
             }
             if (cunit.r<0 && cunit.lp()>=0) {
@@ -435,8 +437,10 @@ class TableDiff {
                 if (active_column!=null) {
                     if (allow_update) {
                         active_column[j] = 1;
-                        col_deletes++;
                     }
+                }
+                if (allow_update) {
+                    col_deletes++;
                 }
             }
             if (cunit.r>=0 && cunit.lp()>=0) {

--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -69,8 +69,10 @@ class TableDiff {
 
     private var col_deletes : Int;
     private var col_inserts : Int;
+    private var col_updates : Int;
     private var col_renames : Int;
     private var col_reorders : Int;
+    private var column_units_updated : Map<Int,Bool>;
 
     private var nested : Bool;
     private var nesting_present : Bool;
@@ -276,8 +278,10 @@ class TableDiff {
         row_reorders = 0;
         col_deletes = 0;
         col_inserts = 0;
+        col_updates = 0;
         col_renames = 0;
         col_reorders = 0;
+        column_units_updated = new Map<Int,Bool>();
     }
 
     private function setupTables() : Void {
@@ -918,6 +922,10 @@ class TableDiff {
                     cell = builder.conflict(dd,dd_to_alt,dd_to);
                     act = conflict_sep;
                 }
+                if (!column_units_updated.exists(j)) {
+                    column_units_updated.set(j,true);
+                    col_updates++;
+                }
             }
             if (act == "" && have_addition) {
                 act = "+";
@@ -1164,6 +1172,7 @@ class TableDiff {
         ds.row_reorders = row_reorders;
         ds.col_deletes = col_deletes;
         ds.col_inserts = col_inserts;
+        ds.col_updates = col_updates;
         ds.col_renames = col_renames;
         ds.col_reorders = col_reorders;
         ds.row_count_initial_with_header = align.getSource().height;

--- a/harness/BasicTest.hx
+++ b/harness/BasicTest.hx
@@ -8,6 +8,7 @@ class BasicTest extends haxe.unit.TestCase {
     var data3 : Array<Array<Dynamic>>;
     var data4 : Array<Array<Dynamic>>;
     var data5 : Array<Array<Dynamic>>;
+    var data6 : Array<Array<Dynamic>>;
 
     override public function setup() {
         data1 = [['Country','Capital'],
@@ -33,6 +34,11 @@ class BasicTest extends haxe.unit.TestCase {
                  ['France','xfr','Parisx'],
                  ['Spain','es','Madridx'],
                  ['Germany','de','Berlinx']];
+        data6 = [['Country','Time','Code','Capital','Golfers'],
+                 ['Ireland',0,'ie','Baile Atha Cliath',1000],
+                 ['France',1,'fr','Paris',10000],
+                 ['Spain',1,'es','Madrid',2000],
+                 ['Germany',null,'de','Berlin',2]];
     }
 
     public function testBasic(){
@@ -224,5 +230,35 @@ class BasicTest extends haxe.unit.TestCase {
         highlighter.hilite(table_diff);
         var summary = highlighter.getSummary();
         assertEquals(summary.col_updates,2);
+    }
+
+    public function testCountAddAndMoveColumns() {
+        var table1 = Native.table(data4);
+        var table2 = Native.table(data6);
+        var alignment = coopy.Coopy.compareTables(table1,table2).align();
+        var data_diff = [];
+        var table_diff = Native.table(data_diff);
+        var flags = new coopy.CompareFlags();
+        var highlighter = new coopy.TableDiff(alignment,flags);
+        highlighter.hilite(table_diff);
+        var summary = highlighter.getSummary();
+        assertEquals(summary.col_inserts,1);
+        assertEquals(summary.col_reorders,1);
+        assertEquals(summary.col_deletes,0);
+    }
+
+    public function testCountAddAndMoveColumnsReversed() {
+        var table1 = Native.table(data6);
+        var table2 = Native.table(data4);
+        var alignment = coopy.Coopy.compareTables(table1,table2).align();
+        var data_diff = [];
+        var table_diff = Native.table(data_diff);
+        var flags = new coopy.CompareFlags();
+        var highlighter = new coopy.TableDiff(alignment,flags);
+        highlighter.hilite(table_diff);
+        var summary = highlighter.getSummary();
+        assertEquals(summary.col_inserts,0);
+        assertEquals(summary.col_reorders,1);
+        assertEquals(summary.col_deletes,1);
     }
 }

--- a/harness/BasicTest.hx
+++ b/harness/BasicTest.hx
@@ -39,6 +39,36 @@ class BasicTest extends haxe.unit.TestCase {
         var highlighter = new coopy.TableDiff(alignment,flags);
         highlighter.hilite(table_diff);
         assertEquals(""+table_diff.getCell(0,4),"->");
+        assertTrue(highlighter.hasDifference());
+        var summary = highlighter.getSummary();
+        assertEquals(summary.row_deletes, 0);
+        assertEquals(summary.row_inserts, 1);
+        assertEquals(summary.row_updates, 1);
+        assertEquals(summary.col_deletes, 0);
+        assertEquals(summary.col_inserts, 1);
+        assertEquals(summary.row_count_initial_with_header, 4);
+        assertEquals(summary.row_count_final_with_header, 5);
+        assertEquals(summary.row_count_initial, 3);
+        assertEquals(summary.row_count_final, 4);
+        assertEquals(summary.col_count_initial, 2);
+        assertEquals(summary.col_count_final, 3);
+    }
+
+    public function testBasicReversed(){
+        var table1 = Native.table(data1);
+        var table2 = Native.table(data2);
+        var alignment = coopy.Coopy.compareTables(table2,table1).align();
+        var data_diff = [];
+        var table_diff = Native.table(data_diff);
+        var flags = new coopy.CompareFlags();
+        var highlighter = new coopy.TableDiff(alignment,flags);
+        highlighter.hilite(table_diff);
+        var summary = highlighter.getSummary();
+        assertEquals(summary.row_deletes, 1);
+        assertEquals(summary.row_inserts, 0);
+        assertEquals(summary.row_updates, 1);
+        assertEquals(summary.col_deletes, 1);
+        assertEquals(summary.col_inserts, 0);
     }
 
     public function testBasicModern(){

--- a/harness/BasicTest.hx
+++ b/harness/BasicTest.hx
@@ -7,6 +7,7 @@ class BasicTest extends haxe.unit.TestCase {
     var data2 : Array<Array<Dynamic>>;
     var data3 : Array<Array<Dynamic>>;
     var data4 : Array<Array<Dynamic>>;
+    var data5 : Array<Array<Dynamic>>;
 
     override public function setup() {
         data1 = [['Country','Capital'],
@@ -27,6 +28,11 @@ class BasicTest extends haxe.unit.TestCase {
                  ['France','fr','Paris',1],
                  ['Spain','es','Madrid',1],
                  ['Germany','de','Berlin',null]];
+        data5 = [['Country','Code','Capital'],
+                 ['Ireland','xie','Dublinx'],
+                 ['France','xfr','Parisx'],
+                 ['Spain','es','Madridx'],
+                 ['Germany','de','Berlinx']];
     }
 
     public function testBasic(){
@@ -41,17 +47,18 @@ class BasicTest extends haxe.unit.TestCase {
         assertEquals(""+table_diff.getCell(0,4),"->");
         assertTrue(highlighter.hasDifference());
         var summary = highlighter.getSummary();
-        assertEquals(summary.row_deletes, 0);
-        assertEquals(summary.row_inserts, 1);
-        assertEquals(summary.row_updates, 1);
-        assertEquals(summary.col_deletes, 0);
-        assertEquals(summary.col_inserts, 1);
-        assertEquals(summary.row_count_initial_with_header, 4);
-        assertEquals(summary.row_count_final_with_header, 5);
-        assertEquals(summary.row_count_initial, 3);
-        assertEquals(summary.row_count_final, 4);
-        assertEquals(summary.col_count_initial, 2);
-        assertEquals(summary.col_count_final, 3);
+        assertEquals(summary.row_deletes,0);
+        assertEquals(summary.row_inserts,1);
+        assertEquals(summary.row_updates,1);
+        assertEquals(summary.col_deletes,0);
+        assertEquals(summary.col_inserts,1);
+        assertEquals(summary.col_updates,1);
+        assertEquals(summary.row_count_initial_with_header,4);
+        assertEquals(summary.row_count_final_with_header,5);
+        assertEquals(summary.row_count_initial,3);
+        assertEquals(summary.row_count_final,4);
+        assertEquals(summary.col_count_initial,2);
+        assertEquals(summary.col_count_final,3);
     }
 
     public function testBasicReversed(){
@@ -64,11 +71,12 @@ class BasicTest extends haxe.unit.TestCase {
         var highlighter = new coopy.TableDiff(alignment,flags);
         highlighter.hilite(table_diff);
         var summary = highlighter.getSummary();
-        assertEquals(summary.row_deletes, 1);
-        assertEquals(summary.row_inserts, 0);
-        assertEquals(summary.row_updates, 1);
-        assertEquals(summary.col_deletes, 1);
-        assertEquals(summary.col_inserts, 0);
+        assertEquals(summary.row_deletes,1);
+        assertEquals(summary.row_inserts,0);
+        assertEquals(summary.row_updates,1);
+        assertEquals(summary.col_deletes,1);
+        assertEquals(summary.col_inserts,0);
+        assertEquals(summary.col_updates,1);
     }
 
     public function testBasicModern(){
@@ -203,5 +211,18 @@ class BasicTest extends haxe.unit.TestCase {
         var table = coopy.Coopy.diff(table1,table1,flags);
         assertEquals(4,table.height);
         assertEquals(3,table.width);
+    }
+
+    public function testCountColumnChanges() {
+        var table1 = Native.table(data2);
+        var table2 = Native.table(data5);
+        var alignment = coopy.Coopy.compareTables(table1,table2).align();
+        var data_diff = [];
+        var table_diff = Native.table(data_diff);
+        var flags = new coopy.CompareFlags();
+        var highlighter = new coopy.TableDiff(alignment,flags);
+        highlighter.hilite(table_diff);
+        var summary = highlighter.getSummary();
+        assertEquals(summary.col_updates,2);
     }
 }


### PR DESCRIPTION
After `TableDiff.hilite` has been used to produce a diff, the `getSummary` method can be called to get an overall summary of what changed, including counts of row insertions, deletions, etc.

Motivated by https://github.com/paulfitz/daff/issues/87.  Does this look like it would meet your need @gwarnes-mdsol?