### PR TITLE
speed up rendering of output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 install:
   - sudo apt-get install time php5 sqlite3 -y
   - if ! $USE_PAULFITZ; then sudo apt-get install haxe -y; fi
-  - if $USE_PAULFITZ; then wget https://github.com/paulfitz/haxe/releases/download/rb_v3.1.1_12/haxerb.zip; fi
+  - if $USE_PAULFITZ; then wget https://github.com/paulfitz/haxe/releases/download/rb_v3.1.1_16/haxerb.zip; fi
   - if $USE_PAULFITZ; then unzip -q haxerb.zip; fi
   - sudo apt-get install gcc-multilib g++-multilib -y  # VM is 64bit but hxcpp builds 32bit
   - mkdir -p ~/haxelib

--- a/coopy/Csv.hx
+++ b/coopy/Csv.hx
@@ -48,20 +48,20 @@ class Csv {
             eol = "\r\n"; // The "standard" says line endings should be this
         }
         var result: String = "";
-        var txt : String = "";
         var v : View = t.getCellView();
         var stream = new TableStream(t);
         var w = stream.width();
+        var txts = new Array<String>();
         while (stream.fetch()) {
             for (x in 0...w) {
                 if (x>0) {
-                    txt += delim;
+                    txts.push(delim);
                 }
-                txt += renderCell(v,stream.getCell(x));
+                txts.push(renderCell(v,stream.getCell(x)));
             }
-            txt += eol;
+            txts.push(eol);
         }
-        return txt;
+        return txts.join("");
     }
 
     /**

--- a/coopy/TerminalDiffRender.hx
+++ b/coopy/TerminalDiffRender.hx
@@ -64,7 +64,6 @@ class TerminalDiffRender {
         var result: String = "";
         var w : Int = t.width;
         var h : Int = t.height;
-        var txt : String = "";
         this.t = t;
         v = t.getCellView();
 
@@ -82,6 +81,7 @@ class TerminalDiffRender {
         var sizes = null;
         if (align_columns) sizes = pickSizes(t);
 
+        var txts = new Array<String>();
         for (y in 0...h) {
             var target = 0;
             var at = 0;
@@ -89,27 +89,29 @@ class TerminalDiffRender {
                 if (sizes!=null) {
                     var spaces = target-at;
                     for (i in 0...spaces) {
-                        txt += " ";
+                        txts.push(" ");
                         at++;
                     }
                 }
                 if (x>0) {
-                    txt += codes["minor"] + delim + codes["done"];
+                    txts.push(codes["minor"]);
+                    txts.push(delim);
+                    txts.push(codes["done"]);
                 }
-                txt += getText(x,y,true);
+                txts.push(getText(x,y,true));
                 if (sizes!=null) {
                     var bit = getText(x,y,false);
                     at += bit.length;
                     target += sizes[x];
                 }
             }
-            txt += "\r\n";
+            txts.push("\r\n");
         }
         this.t = null;
         v = null;
         csv = null;
         codes = null;
-        return txt;
+        return txts.join("");
     }
 
     private function getText(x: Int, y: Int, color: Bool) : String {


### PR DESCRIPTION
A report from @rversteegen showed some inefficiencies.  There
may be multiple sources, but the clearest one in python2 is
on output, where there's some text concatenation going on.
This commit speeds that process up.

https://github.com/paulfitz/daff/issues/53#issuecomment-355704525