### PR TITLE
don't quote fields just because they contain a single quote

### DIFF
--- a/coopy/Csv.hx
+++ b/coopy/Csv.hx
@@ -90,7 +90,7 @@ class Csv {
         if (!need_quote) {
             for (i in 0...str.length) {
                 var ch : String = str.charAt(i);
-                if (ch=='"'||ch=='\''||ch=='\r'||ch=='\n'||ch=='\t') {
+                if (ch=='"'||ch=='\r'||ch=='\n'||ch=='\t') {
                     need_quote = true;
                     break;
                 }

--- a/test/test_csv.js
+++ b/test/test_csv.js
@@ -9,3 +9,10 @@ new coopy.Csv().parseTable(txt,quote_me);
 assert.equal("double \"quotes\" repeated",quote_me.getCell(2,8));
 assert.equal("new\nlines",quote_me.getCell(1,5));
 assert.equal("and 'embedded'",quote_me.getCell(0,6));
+
+var imf_in = "the IMF's Balance of Payments Manual (BPM6),foo,\"bar\",baz',\"boo\"\"z\"";
+var imf_out_expect = "the IMF's Balance of Payments Manual (BPM6),foo,bar,baz',\"boo\"\"z\"";
+var imf_table = new coopy.SimpleTable(0,0);
+new coopy.Csv().parseTable(imf_in,imf_table);
+var imf_out = new coopy.Csv().renderTable(imf_table).replace(/[\n\r]/g, '');
+assert.equal(imf_out_expect, imf_out);


### PR DESCRIPTION
Daff was quoting more aggressively than needed.  This change harmonizes it with other tools.  Thanks @jheeffer, see #105.