### PR TITLE
fix getDiffAsHtml method for single tables

### DIFF
--- a/coopy/DiffRender.hx
+++ b/coopy/DiffRender.hx
@@ -370,10 +370,12 @@ class DiffRender {
 
     public function renderTables(tabs: Tables) : DiffRender {
         var order : Array<String> = tabs.getOrder();
-        if (order.length==0 || tabs.hasInsDel()) {
+        var start = 0;
+        if (order.length<=1 || tabs.hasInsDel()) {
             render(tabs.one());
+            start = 1;
         }
-        for (i in 1...order.length) {
+        for (i in start...order.length) {
             var name = order[i];
             var tab : Table = tabs.get(name);
             if (tab.height<=1) continue;

--- a/harness/BasicTest.hx
+++ b/harness/BasicTest.hx
@@ -201,6 +201,14 @@ class BasicTest extends haxe.unit.TestCase {
         assertTrue(txt.indexOf("Germany")>=0);
     }
 
+    public function testHtmlOutput() {
+        var table1 = Native.table(data1);
+        var table2 = Native.table(data2);
+        var txt = coopy.Coopy.diffAsHtml(table1, table2);
+        trace(txt);
+        assertTrue(txt.indexOf("Germany")>=0);
+    }
+
     public function testStraySpaceInCsv() {
         var csv = new coopy.Csv();
         var tab = csv.makeTable("id,color\n" +


### PR DESCRIPTION
This method appears to only give good results for multiple-table inputs (like a sqlite database) right now; this makes it give output for the straightforward case of comparing two single tables. See #111.