### PR TITLE
make daff easier to use from webpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ js:
 	cat env/js/fix_exports.js >> lib/daff.js
 	cat env/js/table_view.js >> lib/daff.js
 	cat env/js/ndjson_table_view.js >> lib/daff.js
+	cat env/js/fix_exports_some_more.js >> lib/daff.js
+	cp lib/daff.js lib/core.js  # brutally freeze a web-compatible core
 	cat env/js/sqlite_database.js >> lib/daff.js
 	cat env/js/util.js >> lib/daff.js
 	@echo "#######################################################"

--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -1205,7 +1205,7 @@ class Coopy {
 
         // emergency! try to find and use native wrapper
 #if js
-        return untyped __js__("new (typeof exports != 'undefined' ? exports : window).daff.TableView(data)");
+        return untyped __js__("new daff.TableView(data)");
 #elseif python
         python.Syntax.pythonCode("daff = __import__('daff')");
         return python.Syntax.pythonCode("daff.PythonTableView(data)");

--- a/env/js/fix_exports.js
+++ b/env/js/fix_exports.js
@@ -1,6 +1,6 @@
 
-
-if (typeof exports != "undefined") {
+var daff = null;
+if (exports.coopy) {
     // avoid having excess nesting (coopy.coopy) when using node
     for (f in exports.coopy) { 
 	if (exports.coopy.hasOwnProperty(f)) {
@@ -13,6 +13,7 @@ if (typeof exports != "undefined") {
 	    exports[f] = exports.Coopy[f]; 
 	}
     } 
+    daff = exports;
 } else {
     // promote methods of coopy.Coopy
     for (f in coopy.Coopy) { 
@@ -20,5 +21,5 @@ if (typeof exports != "undefined") {
 	    coopy[f] = coopy.Coopy[f]; 
 	}
     } 
-    daff = coopy;
+    window.daff = daff = coopy;
 }

--- a/env/js/fix_exports_some_more.js
+++ b/env/js/fix_exports_some_more.js
@@ -1,0 +1,8 @@
+if (typeof exports != "undefined" && typeof window != "undefined") {
+  // looking at you webpack
+  for (f in daff) { 
+    if (daff.hasOwnProperty(f)) {
+      exports[f] = daff[f]; 
+    }
+  } 
+}

--- a/env/js/ndjson_table_view.js
+++ b/env/js/ndjson_table_view.js
@@ -1,16 +1,5 @@
 (function() {
 
-var coopy = null;
-if (typeof exports != "undefined") {
-    if (typeof exports.Coopy != "undefined") {
-	coopy = exports;
-    }
-}
-if (coopy == null) {
-    coopy = window.daff;
-}
-
-
 /**
  *
  * Wrapper around a table expressed as rows of hashes.  A mapping function can be passed if the
@@ -73,11 +62,11 @@ NdjsonTable.prototype.setCell = function(x,y,c) {
 }
 
 NdjsonTable.prototype.toString = function() {
-    return coopy.SimpleTable.tableToString(this);
+    return daff.SimpleTable.tableToString(this);
 }
 
 NdjsonTable.prototype.getCellView = function() {
-    return new coopy.CellView();
+    return new daff.CellView();
 }
 
 NdjsonTable.prototype.isResizable = function() {
@@ -122,11 +111,6 @@ NdjsonTable.prototype.getMeta = function() {
 }
 
 
-if (typeof exports != "undefined") {
-    exports.NdjsonTable = NdjsonTable;
-} else {
-    if (typeof window["daff"] == "undefined") window["daff"] = {};
-    window.daff.NdjsonTable = NdjsonTable;
-}
+daff.NdjsonTable = NdjsonTable;
 
 })();

--- a/env/js/sqlite_database.js
+++ b/env/js/sqlite_database.js
@@ -1,6 +1,4 @@
-if (typeof exports != "undefined") {
     (function() {
-	var daff = exports;
 
 	SqliteDatabase = function(db,fname,Fiber) {
 	    this.db = db;
@@ -139,4 +137,3 @@ if (typeof exports != "undefined") {
 	exports.SqliteDatabase = SqliteDatabase;
 
     })();
-}

--- a/env/js/table_view.js
+++ b/env/js/table_view.js
@@ -1,15 +1,5 @@
 (function() {
 
-var coopy = null;
-if (typeof exports != "undefined") {
-    if (typeof exports.Coopy != "undefined") {
-	coopy = exports;
-    }
-}
-if (coopy == null) {
-    coopy = window.daff;
-}
-
 var CellView = function() {
 }
 
@@ -83,12 +73,11 @@ TableView.prototype.setCell = function(x,y,c) {
 }
 
 TableView.prototype.toString = function() {
-    return coopy.SimpleTable.tableToString(this);
+    return daff.SimpleTable.tableToString(this);
 }
 
 TableView.prototype.getCellView = function() {
     return new CellView();
-    //return new coopy.SimpleView();
 }
 
 TableView.prototype.isResizable = function() {
@@ -247,18 +236,9 @@ TableView.prototype.getMeta = function() {
     return null;
 }
 
-coopy.TableView = TableView;
+daff.TableView = TableView;
 
-if (typeof exports != "undefined") {
-    exports.CellView = CellView;
-    exports.TableView = TableView;
-    if (typeof exports["daff"] == "undefined") exports["daff"] = exports["coopy"];
-    exports.daff.CellView = CellView;
-    exports.daff.TableView = TableView;
-} else {
-    if (typeof window["daff"] == "undefined") window["daff"] = {};
-    window.daff.CellView = CellView;
-    window.daff.TableView = TableView;
-}
+daff.CellView = CellView;
+daff.TableView = TableView;
 
 })();

--- a/env/js/util.js
+++ b/env/js/util.js
@@ -1,4 +1,4 @@
-if (typeof exports != "undefined") {
+if (true) {
     
     var tio = {};
     var tio_args = [];
@@ -168,8 +168,8 @@ if (typeof exports != "undefined") {
 	return code;
     }
     
-    exports.run_daff_main = function() {
-	var main = new exports.Coopy();
+    daff.run_daff_main = function() {
+	var main = new daff.Coopy();
 	var code = run_daff_base(main,process.argv.slice(2));
 	if (code!=999) {
             if (code!=0) {
@@ -178,8 +178,8 @@ if (typeof exports != "undefined") {
 	}
     }
 
-    exports.cmd = function(args) {
-	var main = new exports.Coopy();
+    daff.cmd = function(args) {
+	var main = new daff.Coopy();
 	var code = run_daff_base(main,args);
 	return code;
     }
@@ -188,7 +188,7 @@ if (typeof exports != "undefined") {
 if (typeof require != "undefined") {
     if (require.main === module) {
 	try {
-	    exports.run_daff_main();
+	    daff.run_daff_main();
 	} catch (e) {
 	    if (("" + e).indexOf("run inside Fiber plz") !== -1) {
 		try {
@@ -199,7 +199,7 @@ if (typeof require != "undefined") {
 		    console.log("No sqlite3/fibers");
 		}
 		Fiber(function() {
-		    exports.run_daff_main();
+		    daff.run_daff_main();
 		}).run();
             } else {
                 throw(e);


### PR DESCRIPTION
Currently it takes some fiddling around to make daff work with
webpack.  After this change, it gets a lot smoother, so something
like this works:

```js
import daff from 'daff/lib/core';

function testDaff() {
  const data1 = [
    ['Country','Capital'],
    ['Ireland','Dublin'],
    ['France','Paris'],
    ['Spain','Barcelona']
  ];
  const data2 = [
    ['Country','Code','Capital'],
    ['Ireland','ie','Dublin'],
    ['France','fr','Paris'],
    ['Spain','es','Madrid'],
    ['Germany','de','Berlin']
  ];
  const alignment = daff.compareTables(data1, data2).align();
  const diff = new daff.TableView([]);
  const highlighter = new daff.TableDiff(alignment, new daff.CompareFlags());
  highlighter.hilite(diff);
  return new daff.DiffRender().render(diff).html();
}

function component() {
  const element = document.createElement('div');
  element.innerHTML = testDaff();
  return element;
}

document.body.appendChild(component());
```

A new `daff/lib/core` import is added that excludes material that
requires access to a non-browser environment.