### PR TITLE
don't swallow final newline when rendering plain CSV

### DIFF
--- a/coopy/Csv.hx
+++ b/coopy/Csv.hx
@@ -136,6 +136,9 @@ class Csv {
                 line_buf+=ch;
             }
         }
+        if (line_buf.length>0) {
+            result += line_buf;
+        }
         if (need_quote) { result += '"'; }
         return result;
     }

--- a/harness/BasicTest.hx
+++ b/harness/BasicTest.hx
@@ -134,6 +134,17 @@ class BasicTest extends haxe.unit.TestCase {
         assertEquals("BOR",tab.getCell(1,1));
     }
 
+    public function testCSVWithFinalNewline() {
+        var txt = "name,age\nPaul,\"\n\"\n";
+        var tab = Native.table([]);
+        var csv = new coopy.Csv(',','\n');
+        csv.parseTable(txt,tab);
+        assertEquals(2,tab.height);
+        assertEquals(2,tab.width);
+        var out = csv.renderTable(tab);
+        assertEquals(txt,out);
+    }
+
     public function testEmpty() {
         var table1 = Native.table(data1);
         var table2 = Native.table([]);
@@ -210,7 +221,6 @@ class BasicTest extends haxe.unit.TestCase {
         var table1 = Native.table(data1);
         var table2 = Native.table(data2);
         var txt = coopy.Coopy.diffAsHtml(table1, table2);
-        trace(txt);
         assertTrue(txt.indexOf("Germany")>=0);
     }
 


### PR DESCRIPTION
Pass through a final newline/linefeed when rendering a CSV cell, if there is one.  See #95.