### PR TITLE
allow inserted cells from a new column to be controlled separately

### DIFF
--- a/coopy/CompareFlags.hx
+++ b/coopy/CompareFlags.hx
@@ -282,7 +282,7 @@ class CompareFlags {
      */
     public function allowUpdate() : Bool {
         if (acts==null) return true;
-        return acts.exists("update");
+        return acts.exists("update") && acts.get("update");
     }
 
     /**
@@ -292,7 +292,7 @@ class CompareFlags {
      */
     public function allowInsert() : Bool {
         if (acts==null) return true;
-        return acts.exists("insert");
+        return acts.exists("insert") && acts.get("insert");
     }
 
     /**
@@ -302,7 +302,7 @@ class CompareFlags {
      */
     public function allowDelete() : Bool {
         if (acts==null) return true;
-        return acts.exists("delete");
+        return acts.exists("delete") && acts.get("delete");
     }
 
     /**
@@ -312,7 +312,7 @@ class CompareFlags {
      */
     public function allowColumn() : Bool {
         if (acts==null) return true;
-        return acts.exists("column");
+        return acts.exists("column") && acts.get("column");
     }
 
     /**

--- a/coopy/CompareFlags.hx
+++ b/coopy/CompareFlags.hx
@@ -256,7 +256,7 @@ class CompareFlags {
     /**
      *
      * Filter for particular kinds of changes.
-     * @param act set this to "update", "insert", or "delete"
+     * @param act set this to "update", "insert", "delete", or "column".
      * @param allow set this to true to allow this kind, or false to
      * deny it.
      * @return true if the kind of change was recognized.
@@ -268,6 +268,7 @@ class CompareFlags {
             acts.set("update",!allow);
             acts.set("insert",!allow);
             acts.set("delete",!allow);
+            acts.set("column",!allow);
         }
         if (!acts.exists(act)) return false;
         acts.set(act,allow);
@@ -302,6 +303,16 @@ class CompareFlags {
     public function allowDelete() : Bool {
         if (acts==null) return true;
         return acts.exists("delete");
+    }
+
+    /**
+     *
+     * @return true if column additions/deletions are allowed by the current filters.
+     *
+     */
+    public function allowColumn() : Bool {
+        if (acts==null) return true;
+        return acts.exists("column");
     }
 
     /**

--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -976,7 +976,7 @@ class Coopy {
                     io.writeStderr("\n");
                     io.writeStderr("If you need more control, here is the full list of flags:\n");
                     io.writeStderr("  daff diff [--output OUTPUT.csv] [--context NUM] [--all] [--act ACT] a.csv b.csv\n");
-                    io.writeStderr("     --act ACT:     show only a certain kind of change (update, insert, delete)\n");
+                    io.writeStderr("     --act ACT:     show only a certain kind of change (update, insert, delete, column)\n");
                     io.writeStderr("     --all:         do not prune unchanged rows or columns\n");
                     io.writeStderr("     --all-rows:    do not prune unchanged rows\n");
                     io.writeStderr("     --all-columns: do not prune unchanged columns\n");

--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -892,7 +892,7 @@ class TableDiff {
             }
 
             var cell : Dynamic = dd;
-            if (have_dd_to&&((dd&&allow_update)||allow_column)) {
+            if (have_dd_to&&((dd!=null&&allow_update)||allow_column)) {
                 if (!row_update) {
                     if (out==0) row_updates++;
                     row_update = true;

--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -42,6 +42,7 @@ class TableDiff {
     private var allow_insert : Bool;
     private var allow_delete : Bool;
     private var allow_update : Bool;
+    private var allow_column : Bool;
 
     private var v : View;
 
@@ -266,7 +267,7 @@ class TableDiff {
         show_rc_numbers = false;
         row_moves = null;
         col_moves = null;
-        allow_insert = allow_delete = allow_update = true;
+        allow_insert = allow_delete = allow_update = allow_column = true;
         sep = "";
         conflict_sep = "";
         top_line_done = false;
@@ -325,6 +326,7 @@ class TableDiff {
         allow_insert = flags.allowInsert();
         allow_delete = flags.allowDelete();
         allow_update = flags.allowUpdate();
+        allow_column = flags.allowColumn();
 
         var common = a;
         if (common==null) common = b;
@@ -423,11 +425,11 @@ class TableDiff {
                 have_schema = true;
                 act = "+++";
                 if (active_column!=null) {
-                    if (allow_update) {
+                    if (allow_column) {
                         active_column[j] = 1;
                     }
                 }
-                if (allow_update) {
+                if (allow_column) {
                     col_inserts++;
                 }
             }
@@ -435,11 +437,11 @@ class TableDiff {
                 have_schema = true;
                 act = "---";
                 if (active_column!=null) {
-                    if (allow_update) {
+                    if (allow_column) {
                         active_column[j] = 1;
                     }
                 }
-                if (allow_update) {
+                if (allow_column) {
                     col_deletes++;
                 }
             }
@@ -828,7 +830,7 @@ class TableDiff {
                 if ((have_pp ? cunit.p : cunit.l)<0) {
                     if (rr != null) {
                         if (v.toString(rr) != "") {
-                            if (flags.allowUpdate()) {
+                            if (allow_column) {
                                 have_addition = true;
                             }
                         }
@@ -890,7 +892,7 @@ class TableDiff {
             }
 
             var cell : Dynamic = dd;
-            if (have_dd_to&&allow_update) {
+            if (have_dd_to&&((dd&&allow_update)||allow_column)) {
                 if (!row_update) {
                     if (out==0) row_updates++;
                     row_update = true;

--- a/harness/BasicTest.hx
+++ b/harness/BasicTest.hx
@@ -210,7 +210,6 @@ class BasicTest extends haxe.unit.TestCase {
         var table1 = Native.table(data1);
         var table2 = Native.table(data2);
         var txt = coopy.Coopy.diffAsHtml(table1, table2);
-        trace(txt);
         assertTrue(txt.indexOf("Germany")>=0);
     }
 
@@ -292,4 +291,37 @@ class BasicTest extends haxe.unit.TestCase {
         assertTrue(render1.indexOf("&lt;i&gt;Paris&lt;/i&gt;") != -1);
         assertTrue(render2.indexOf("<i>Paris</i>") != -1);
     }
+
+    public function testIgnoreTypesOfChanges() {
+        var table1 = Native.table(data1);
+        var table2 = Native.table(data2);
+        var flags = new coopy.CompareFlags();
+        flags.unchanged_context = 0;
+        flags.filter("column", false);
+        var data_diff = coopy.Coopy.diff(table1,table2,flags);
+        assertEquals(4,data_diff.height);
+        flags.filter("insert", false);
+        data_diff = coopy.Coopy.diff(table1,table2,flags);
+        assertEquals(3,data_diff.height);
+        flags.filter("update", false);
+        data_diff = coopy.Coopy.diff(table1,table2,flags);
+        assertEquals(2,data_diff.height);
+        data_diff = coopy.Coopy.diff(table2,table1,flags);
+        assertEquals(3,data_diff.height);
+        flags.filter("delete", false);
+        data_diff = coopy.Coopy.diff(table2,table1,flags);
+        assertEquals(2,data_diff.height);
+        flags = new coopy.CompareFlags();
+        flags.unchanged_context = 0;
+        flags.filter("insert", true);
+        data_diff = coopy.Coopy.diff(table1,table2,flags);
+        assertEquals(3,data_diff.height);
+        flags.filter("update", true);
+        data_diff = coopy.Coopy.diff(table1,table2,flags);
+        assertEquals(4,data_diff.height);
+        flags.filter("column", true);
+        data_diff = coopy.Coopy.diff(table1,table2,flags);
+        assertEquals(6,data_diff.height);
+    }
+
 }


### PR DESCRIPTION
Currently it is possible to independently specify whether to include inserted, deleted, or updated rows in a diff with the `--act` flag. But if a column is inserted, there's no way to control whether the cells added to each row are included in the diff or not.  Currently, they are somewhat randomly included in the `update` category.  This diff breaks them out as independently controllable.

So to include all changes but the cells of inserted columns, it would suffice to do:
```
daff --act update --act insert --act delete v1.csv v2.csv
```

See #118.