### PR TITLE
distinguish blanks and nulls when generating diffs

### DIFF
--- a/coopy/SimpleView.hx
+++ b/coopy/SimpleView.hx
@@ -23,8 +23,7 @@ class SimpleView implements View {
     
     public function equals(d1: Dynamic, d2: Dynamic) : Bool {
         if (d1==null && d2==null) return true;
-        if (d1==null && (""+d2)=="") return true;
-        if ((""+d1)=="" && d2==null) return true;
+        if (d1==null || d2==null) return false;
         return ("" + d1) == ("" + d2);
     }
 

--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -136,23 +136,6 @@ class TableDiff {
         return sep;
     }
 
-    private function quoteForDiff(v: View, d: Dynamic) : String {
-        var nil : String = "NULL";
-        if (v.equals(d,null)) {
-            return nil;
-        }
-        var str : String = v.toString(d);
-        var score : Int = 0;
-        for (i in 0...str.length) {
-            if (str.charCodeAt(score)!='_'.code) break;
-            score++;
-        }
-        if (str.substr(score)==nil) {
-            str = "_" + str;
-        }
-        return str;
-    }
-
     private function isReordered(m: Map<Int,Unit>, ct: Int) : Bool {
         var reordered : Bool = false;
         var l : Int = -1;

--- a/env/php/PhpCellView.class.php
+++ b/env/php/PhpCellView.class.php
@@ -5,7 +5,9 @@ class coopy_PhpCellView implements coopy_View {
     return print_r($d,true);
   }
   public function equals($d1,$d2) {
-      return "".$d1 == "".$d2;
+    if ($d1===null&&$d2===null) { return true; }
+    if ($d1===null||$d2===null) { return false; }
+    return "".$d1 == "".$d2;
   }
   public function toDatum($d) { return $d; }
   public function makeHash() { return array(); }

--- a/harness/BasicTest.hx
+++ b/harness/BasicTest.hx
@@ -335,4 +335,31 @@ class BasicTest extends haxe.unit.TestCase {
         assertEquals(6,data_diff.height);
     }
 
+    public function testChangeToBlank() {
+        var v1 = Native.table([["id", "name"], ["1", " "]]);
+        var v2 = Native.table([["id", "name"], ["1", ""]]);
+        var diff = coopy.Coopy.diff(v1,v2);
+        assertEquals(" ->", diff.getCell(2,1));
+    }
+
+    public function testChangeToNull() {
+        var v1 = Native.table([["id", "name"], ["1", ""]]);
+        var v2 = Native.table([["id", "name"], ["1", null]]);
+        var diff = coopy.Coopy.diff(v1,v2);
+        assertEquals("->NULL", diff.getCell(2,1));
+    }
+
+    public function testChangeFromNull() {
+        var v1 = Native.table([["id", "name"], ["1", null]]);
+        var v2 = Native.table([["id", "name"], ["1", ""]]);
+        var diff = coopy.Coopy.diff(v1,v2);
+        assertEquals("NULL->", diff.getCell(2,1));
+    }
+
+    public function testToLiteralStringNull() {
+        var v1 = Native.table([["id", "name"], ["1", null]]);
+        var v2 = Native.table([["id", "name"], ["1", "NULL"]]);
+        var diff = coopy.Coopy.diff(v1,v2);
+        assertEquals("NULL->_NULL", diff.getCell(2,1));
+    }
 }


### PR DESCRIPTION
Some old code was deliberately sloppy about distinguishing blank strings and nulls, inheriting an ambiguity from csv. This tightens this up, and adds tests.  Fixes #96.