### PR TITLE
test wide sparse diffs, and fix them

### DIFF
--- a/coopy/CompareTable.hx
+++ b/coopy/CompareTable.hx
@@ -136,9 +136,11 @@ class CompareTable {
 
         var ids : Array<String> = null;
         var ignore : Map<String,Bool> = null;
+        var ordered : Bool = true;
         if (comp.compare_flags!=null) {
             ids = comp.compare_flags.ids;
             ignore = comp.compare_flags.getIgnoredColumns();
+            ordered = comp.compare_flags.ordered;
         }
  
         var common_units : Array<Unit> = new Array<Unit>();

--- a/coopy/TerminalDiffRender.hx
+++ b/coopy/TerminalDiffRender.hx
@@ -199,7 +199,7 @@ class TerminalDiffRender {
             sizes.push(most);
             total += most;
         }
-        if (total>130) {  // arbitrary wide terminal size
+        if (total>130&&!wide_columns) {  // arbitrary wide terminal size
             return null;
         }
         return sizes;

--- a/test/data/wide1.csv
+++ b/test/data/wide1.csv
@@ -1,0 +1,8 @@
+A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny

--- a/test/data/wide2.csv
+++ b/test/data/wide2.csv
@@ -1,0 +1,8 @@
+A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z
+boom,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,boom,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,boom,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,boom,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,boom,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny
+thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny,zappyier,thing,greeny

--- a/test/test_padding.js
+++ b/test/test_padding.js
@@ -1,0 +1,28 @@
+var fs = require('fs');
+var coopy = require('daff');
+var tester = require('tester');
+var assert = require('assert');
+
+var options = new coopy.CompareFlags();	
+var v1 = tester.readCsv("data/wide1.csv");
+var v2 = tester.readCsv("data/wide2.csv");
+
+// make sure that a wide diff, when configured to be shown in default mode, has no space
+var ct = new coopy.compareTables(v1,v2);
+var td = new coopy.TableDiff(ct.align(),options);
+var output = new coopy.TableView([]);
+td.hilite(output);
+var render = new coopy.TerminalDiffRender(options);
+var txt = render.render(output).replace(/[^ a-z+\-,\n]/g, '').replace(/m/g,'');
+assert.equal(txt.indexOf('  ,thing'),-1);
+
+// make sure that a wide diff, when configured to be shown in sparse mode, contains space
+options.padding_strategy = "sparse";
+ct = new coopy.compareTables(v1,v2);
+td = new coopy.TableDiff(ct.align(),options);
+output = new coopy.TableView([]);
+td.hilite(output);
+render = new coopy.TerminalDiffRender(options);
+txt = render.render(output).replace(/[^ a-z+\-,\n]/g, '').replace(/m/g,'');
+assert.notEqual(txt.indexOf('  ,thing'),-1);
+


### PR DESCRIPTION
Wide diffs currently are rendered densely (without padding) even if the 'sparse' option is set.  This change makes sure that this option is respected.  See #125.