### PR TITLE
make selection of tables and keys more flexible during sql comparison

### DIFF
--- a/coopy/CompareFlags.hx
+++ b/coopy/CompareFlags.hx
@@ -383,5 +383,50 @@ class CompareFlags {
     public function getWarning() : String {
         return warnings.join("\n");
     }
+
+    /**
+     *
+     * Primary key and table names may be specified as "local:remote" or "parent:local:remote"
+     * when they should be different for the local, remote, and parent sources.  This 
+     * method returns the appropriate part of a name given a role of local, remote, or parent.
+     *
+     */
+    public function getNameByRole(name: String, role: String): String {
+        var parts = name.split(":");
+        if (parts.length <= 1) { return name; }
+        if (role == 'parent') {
+            return parts[0];
+        }
+
+        if (role == 'local') {
+            return parts[parts.length - 2];
+        }
+        return parts[parts.length - 1];
+    }
+
+    /**
+     *
+     * If we need a single name for a table/column, we use the local name.
+     *
+     */
+    public function getCanonicalName(name: String): String {
+        return getNameByRole(name, 'local');
+    }
+
+    /**
+     *
+     * Returns primary key for 'local', 'remote', and 'parent' sources.
+     *
+     */
+    public function getIdsByRole(role: String): Array<String> {
+        var result = new Array<String>();
+        if (ids==null) {
+            return result;
+        }
+        for (name in ids) {
+            result.push(getNameByRole(name, role));
+        }
+        return result;
+    }
 }
 

--- a/coopy/CompareTable.hx
+++ b/coopy/CompareTable.hx
@@ -98,7 +98,7 @@ class CompareTable {
             if (tab1!=null) db = tab1.getDatabase();
             if (db==null && tab2!=null) db = tab2.getDatabase();
             if (db==null && tab3!=null) db = tab3.getDatabase();
-            var sc = new SqlCompare(db,tab1,tab2,tab3,align);
+            var sc = new SqlCompare(db,tab1,tab2,tab3,align,comp.compare_flags);
             sc.apply();
             if (comp.p!=null) {
                 align.meta.reference = align.reference.meta;

--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -216,7 +216,7 @@ class Coopy {
         var hp : HighlightPatch = new HighlightPatch(null,null);
         var csv : Csv = new Csv();
         var tm : TableModifier = new TableModifier(null);
-        var sc: SqlCompare = new SqlCompare(null,null,null,null);
+        var sc: SqlCompare = new SqlCompare(null,null,null,null,null);
         var sq: SqliteHelper = new SqliteHelper();
         var sm : SimpleMeta = new SimpleMeta(null);
         var ct : CombinedTable = new CombinedTable(null);
@@ -496,10 +496,11 @@ class Coopy {
      * Load a table from a file.
      *
      * @param name filename to read from
+     * @param role one of "parent", "local", or "remote"
      * @return a table
      *
      */
-    public function loadTable(name: String) : Table {
+    public function loadTable(name: String, role: String) : Table {
         var ext = checkFormat(name);
         if (ext == "sqlite") {
             var sql = io.openSqliteDatabase(name);
@@ -507,7 +508,7 @@ class Coopy {
                 io.writeStderr("! Cannot open database, aborting\n");
                 return null;
             }
-            var tab = new SqlTables(sql,flags);
+            var tab = new SqlTables(sql,flags,role);
             return tab;
         }
         var txt : String = io.getContent(name);
@@ -1059,15 +1060,15 @@ class Coopy {
             }
             var parent = null;
             if (args.length-offset>=3) {
-                parent = loadTable(args[offset]);
+                parent = loadTable(args[offset], 'parent');
                 offset++;
             }
             var aname = args[0+offset];
-            var a = loadTable(aname);
+            var a = loadTable(aname, 'local');
             var b = null;
             if (args.length-offset>=2) {
                 if (cmd!="copy") {
-                    b = loadTable(args[1+offset]);
+                    b = loadTable(args[1+offset], 'remote');
                 } else {
                     output = args[1+offset];
                 }

--- a/coopy/SqlCompare.hx
+++ b/coopy/SqlCompare.hx
@@ -494,7 +494,7 @@ class SqlCompare {
         }
 
         if (alt!=null) {
-            var sql_inserts : String = "SELECT DISTINCT 0 AS __coopy_code, NULL, " + rowid3 + " AS rowid, NULL, " + sql_all_cols3 + " FROM " + sql_table3;
+            var sql_inserts : String = "SELECT DISTINCT 0 AS __coopy_code, NULL, NULL, " + rowid3 + " AS rowid, " + sql_all_cols3 + " FROM " + sql_table3;
             if (local!=null) {
                 sql_inserts += " LEFT JOIN " + sql_table1;
                 sql_inserts += " ON " + sql_key_match3 + where(sql_key_null);
@@ -526,7 +526,7 @@ class SqlCompare {
 
         if (alt==null) {
             if (local!=null) {
-                var sql_deletes : String = "SELECT DISTINCT 0 AS __coopy_code, NULL, " + rowid1 + " AS rowid, NULL, " + sql_all_cols1 + " FROM " + sql_table1;
+                var sql_deletes : String = "SELECT DISTINCT 0 AS __coopy_code, " + rowid1 + " AS rowid, NULL, NULL, " + sql_all_cols1 + " FROM " + sql_table1;
                 if (remote!=null) {
                     sql_deletes += " LEFT JOIN " + sql_table2;
                     sql_deletes += " ON " + sql_key_match2 + where(sql_key_null2);

--- a/coopy/SqlCompare.hx
+++ b/coopy/SqlCompare.hx
@@ -369,7 +369,7 @@ class SqlCompare {
         if (alt!=null) {
             for (i in 0...(all_cols3.length)) {
                 if (i>0) sql_all_cols3 += ",";
-                sql_all_cols3 += alt.getQuotedColumnName(all_cols3[i]);
+                sql_all_cols3 += sql_table3 + "." + alt.getQuotedColumnName(all_cols3[i]);
             }
         }
         var sql_key_null : String = "";
@@ -487,8 +487,10 @@ class SqlCompare {
                 sql_inserts += " LEFT JOIN " + sql_table1;
                 sql_inserts += " ON " + sql_key_match2 + where(sql_key_null);
             }
-            var sql_inserts_order : Array<String> = ["__coopy_code","NULL","rowid","NULL"].concat(all_cols2);
-            linkQuery(sql_inserts,sql_inserts_order);
+            if (sql_table1!=sql_table2) {
+                var sql_inserts_order : Array<String> = ["__coopy_code","NULL","rowid","NULL"].concat(all_cols2);
+                linkQuery(sql_inserts,sql_inserts_order);
+            }
         }
 
         if (alt!=null) {
@@ -497,8 +499,10 @@ class SqlCompare {
                 sql_inserts += " LEFT JOIN " + sql_table1;
                 sql_inserts += " ON " + sql_key_match3 + where(sql_key_null);
             }
-            var sql_inserts_order : Array<String> = ["__coopy_code","NULL","NULL","rowid"].concat(all_cols3);
-            linkQuery(sql_inserts,sql_inserts_order);
+            if (sql_table1!=sql_table3) {
+                var sql_inserts_order : Array<String> = ["__coopy_code","NULL","NULL","rowid"].concat(all_cols3);
+                linkQuery(sql_inserts,sql_inserts_order);
+            }
         }
 
         if (local!=null && remote!=null) {
@@ -527,8 +531,10 @@ class SqlCompare {
                     sql_deletes += " LEFT JOIN " + sql_table2;
                     sql_deletes += " ON " + sql_key_match2 + where(sql_key_null2);
                 }
-                var sql_deletes_order : Array<String> = ["__coopy_code","rowid","NULL","NULL"].concat(all_cols1);
-                linkQuery(sql_deletes,sql_deletes_order);
+                if (sql_table1!=sql_table2) {
+                    var sql_deletes_order : Array<String> = ["__coopy_code","rowid","NULL","NULL"].concat(all_cols1);
+                    linkQuery(sql_deletes,sql_deletes_order);
+                }
             }
         }
 

--- a/coopy/SqlTables.hx
+++ b/coopy/SqlTables.hx
@@ -10,16 +10,16 @@ class SqlTables implements Table {
     private var t: Table;
     private var flags: CompareFlags;
 
-    public function new(db: SqlDatabase, flags: CompareFlags) {
+    public function new(db: SqlDatabase, flags: CompareFlags, role: String) {
         this.db = db;
         var helper = this.db.getHelper();
         var names = helper.getTableNames(db);
-        var allowed : Map<String,Bool> = null;
+        var allowed : Map<String,String> = null;
         var count : Int = names.length;
         if (flags.tables!=null) {
-            allowed = new Map<String,Bool>();
+            allowed = new Map<String,String>();
             for (name in flags.tables) {
-                allowed.set(name,true);
+                allowed.set(flags.getNameByRole(name, role),flags.getCanonicalName(name));
             }
             count = 0;
             for (name in names) {
@@ -34,10 +34,12 @@ class SqlTables implements Table {
         var v = t.getCellView();
         var at = 1;
         for (name in names) {
+            var cname = name;
             if (allowed!=null) {
                 if (!allowed.exists(name)) continue;
+                cname = allowed.get(name);
             }
-            t.setCell(0,at,name);
+            t.setCell(0,at,cname);
             t.setCell(1,at,v.wrapTable(new SqlTable(db, new SqlTableName(name))));
             at++;
         }

--- a/env/py/sqlite_database.py
+++ b/env/py/sqlite_database.py
@@ -13,6 +13,8 @@ class SqliteDatabase(SqlDatabase):
 
     # needed because pragmas do not support bound parameters
     def getQuotedColumnName(self,name):
+        if hasattr(name,'decode'):
+            name = unicode(name)
         return self.quoter.renderCell(self.view, name, True)
 
     # needed because pragmas do not support bound parameters

--- a/harness/SqlTest.hx
+++ b/harness/SqlTest.hx
@@ -8,6 +8,13 @@ class SqlTest extends haxe.unit.TestCase {
 
     override public function setup() {
         db = Native.openSqlite(":memory:");
+        createTables();
+    }
+
+    public function createTables() {
+        for (name in ["ver1", "ver2", "ver3", "ver4", "ver5", "ver6", "nully1", "nully2"]) {
+            exec(db,"DROP TABLE IF EXISTS "+name);
+        }
         exec(db,"CREATE TABLE ver1 (id INTEGER PRIMARY KEY, name TEXT)");
         exec(db,"CREATE TABLE ver2 (id INTEGER PRIMARY KEY, name TEXT)");
         exec(db,"CREATE TABLE ver3 (id INTEGER PRIMARY KEY, name TEXT, count INTEGER)");
@@ -99,7 +106,7 @@ class SqlTest extends haxe.unit.TestCase {
     }
 
     public function comparePair(name1: String, name2: String) {
-        setup();
+        createTables();
         var st1 = new coopy.SqlTable(db,new coopy.SqlTableName(name1));
         var st2 = new coopy.SqlTable(db,new coopy.SqlTableName(name2));
         flags.show_meta = true;
@@ -116,6 +123,7 @@ class SqlTest extends haxe.unit.TestCase {
                 comparePair(n1,n2);
             }
         }
+        createTables();
     }
 
     public function test3WayDiff() {

--- a/test/integration_sqlite.sh
+++ b/test/integration_sqlite.sh
@@ -56,34 +56,72 @@ INSERT INTO birds VALUES(4,"penguin",5,"cold");
 EOF
 } | sqlite3 birds_v2.sqlite
 
+{
+    cat<<EOF
+CREATE TABLE birds (id INTEGER PRIMARY KEY, name TEXT, count TEXT);
+INSERT INTO birds VALUES(1,"robin","251");
+INSERT INTO birds VALUES(2,"eagle","10");
+INSERT INTO birds VALUES(3,"pigeon","140");
+
+CREATE TABLE birds2 (id INTEGER PRIMARY KEY, name TEXT, count INTEGER, weather TEXT);
+INSERT INTO birds2 VALUES(1,"robin",251,"warm");
+INSERT INTO birds2 VALUES(2,"eagle",10,"");
+INSERT INTO birds2 VALUES(3,"pigeon",140,"");
+INSERT INTO birds2 VALUES(4,"penguin",5,"cold");
+EOF
+} | sqlite3 birds_v12.sqlite
+
+{
+    cat<<EOF
+CREATE TABLE birds (id INTEGER, name TEXT, count TEXT);
+INSERT INTO birds VALUES(1,"robin","251");
+INSERT INTO birds VALUES(2,"eagle","10");
+INSERT INTO birds VALUES(3,"pigeon","140");
+
+CREATE TABLE birds2 (id INTEGER, name TEXT, count INTEGER, weather TEXT);
+INSERT INTO birds2 VALUES(1,"robin",251,"warm");
+INSERT INTO birds2 VALUES(2,"eagle",10,"");
+INSERT INTO birds2 VALUES(3,"pigeon",140,"");
+INSERT INTO birds2 VALUES(4,"penguin",5,"cold");
+EOF
+} | sqlite3 birds_v12_no_key.sqlite
 
 function run_diff {
     v1="$1"
     v2="$2"
-    diff="$3"
-    $DAFF_SCRIPT $v1 $v2 > $diff
+    ref_diff="$3"
+    save_diff="$4"
+    shift
+    shift
+    shift
+    shift
+    $DAFF_SCRIPT $v1 $v2 "$@" > $save_diff
     echo ""
-    echo "$v1 -> $v2 ($diff)"
-    $DAFF_SCRIPT $v1 $v2 # run separately to see color
-    if [ -e $org/test/sqlite/${diff} ]; then
-        diff -w ${diff} $org/test/sqlite/${diff} || {
-            echo "${diff} not created correctly."
+    echo "$v1 -> $v2 ($save_diff)"
+    $DAFF_SCRIPT $v1 $v2 "$@" # run separately to see color
+    if [ -e $org/test/sqlite/${ref_diff} ]; then
+        diff -w ${save_diff} $org/test/sqlite/${ref_diff} || {
+            echo "${save_diff} not created correctly."
             exit 1
         } && {
-            echo "${diff} created correctly."
+            echo "${save_diff} created correctly."
         }
     else
-        echo "${diff} has nothing to compare with."
+        echo "${save_diff} has nothing to compare with."
     fi
 }
 
-run_diff v1.sqlite v2.sqlite basic.diff
-run_diff v1.sqlite v3.sqlite remove_table.diff
-run_diff v3.sqlite v1.sqlite add_table.diff
-run_diff birds_v1.sqlite birds_v2.sqlite type_change.diff
-run_diff $org/test/sqlite/blank.sqlite $org/test/sqlite/awkward.sqlite create_all.diff
+run_diff v1.sqlite v2.sqlite basic.diff basic.diff
+run_diff v1.sqlite v3.sqlite remove_table.diff remove_table.diff
+run_diff v3.sqlite v1.sqlite add_table.diff add_table.diff
+run_diff birds_v1.sqlite birds_v2.sqlite type_change.diff type_change.diff
+run_diff $org/test/sqlite/blank.sqlite $org/test/sqlite/awkward.sqlite create_all.diff create_all.diff
 if [ "$DAFF_LANGUAGE" = "js" ]; then
     # only have energy to tweak this on js for the moment
-    run_diff $org/test/sqlite/blobby1.sqlite $org/test/sqlite/blobby2.sqlite with_blobs.diff
+    run_diff $org/test/sqlite/blobby1.sqlite $org/test/sqlite/blobby2.sqlite with_blobs.diff with_blobs.diff
 fi
 
+run_diff birds_v12.sqlite birds_v12.sqlite type_change.diff type_change_v12.diff --table birds:birds2
+
+run_diff birds_v12_no_key.sqlite birds_v12_no_key.sqlite type_change.diff \
+  type_change_v12_no_key.diff --table birds:birds2 --id id


### PR DESCRIPTION
Now the --table flag can be --table name1:name2 to allow a table
called name1 to be compared with a table called name2.

As a side affect, you can now compare tables within a single
database as follows:

```
 daff --table name1:name2 db.sqlite db.sqlite
```

The --id flag was until now not respected during sql comparison.
Now it is.  This is particularly useful for comparing tables that
don't have a primary key set.  However, comparisons will be
slower using --id since the database will end up recreating
indexes multiple times rather than just once.

The SQL queries were tweaked a bit to work better without an
index, so that million row comparisons continue to take seconds.
Still, do add an index, you'll be happier.