### PR TITLE
mention support for sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ You can run `daff`/`daff.py`/`daff.rb` as a utility program:
 $ daff
 daff can produce and apply tabular diffs.
 Call as:
+  daff a.csv b.csv
   daff [--color] [--no-color] [--output OUTPUT.csv] a.csv b.csv
   daff [--output OUTPUT.html] a.csv b.csv
-  daff [--output OUTPUT.csv] parent.csv a.csv b.csv
-  daff [--output OUTPUT.ndjson] a.ndjson b.ndjson
   daff [--www] a.csv b.csv
-  daff patch [--inplace] [--output OUTPUT.csv] a.csv patch.csv
-  daff merge [--inplace] [--output OUTPUT.csv] parent.csv a.csv b.csv
+  daff parent.csv a.csv b.csv
+  daff --input-format sqlite a.db b.db
+  daff patch [--inplace] a.csv patch.csv
+  daff merge [--inplace] parent.csv a.csv b.csv
   daff trim [--output OUTPUT.csv] source.csv
   daff render [--output OUTPUT.html] diff.csv
   daff copy in.csv out.tsv
@@ -67,22 +68,24 @@ The --inplace option to patch and merge will result in modification of a.csv.
 
 If you need more control, here is the full list of flags:
   daff diff [--output OUTPUT.csv] [--context NUM] [--all] [--act ACT] a.csv b.csv
-     --act ACT:     show only a certain kind of change (update, insert, delete)
+     --act ACT:     show only a certain kind of change (update, insert, delete, column)
      --all:         do not prune unchanged rows or columns
      --all-rows:    do not prune unchanged rows
      --all-columns: do not prune unchanged columns
      --color:       highlight changes with terminal colors (default in terminals)
-     --context NUM: show NUM rows of context
+     --context NUM: show NUM rows of context (0=none)
+     --context-columns NUM: show NUM columns of context (0=none)
+     --fail-if-diff: return status is 0 if equal, 1 if different, 2 if problem
      --id:          specify column to use as primary key (repeat for multi-column key)
      --ignore:      specify column to ignore completely (can repeat)
      --index:       include row/columns numbers from original tables
-     --input-format [csv|tsv|ssv|psv|json]: set format to expect for input
+     --input-format [csv|tsv|ssv|psv|json|sqlite]: set format to expect for input
      --eol [crlf|lf|cr|auto]: separator between rows of csv output.
      --no-color:    make sure terminal colors are not used
      --ordered:     assume row order is meaningful (default for CSV)
      --output-format [csv|tsv|ssv|psv|json|copy|html]: set format for output
      --padding [dense|sparse|smart]: set padding method for aligning columns
-     --table NAME:  compare the named table, used with SQL sources
+     --table NAME:  compare the named table, used with SQL sources. If name changes, use 'n1:n2'
      --unordered:   assume row order is meaningless (default for json formats)
      -w / --ignore-whitespace: ignore changes in leading/trailing whitespace
      -i / --ignore-case: ignore differences in case
@@ -91,10 +94,12 @@ If you need more control, here is the full list of flags:
      --css CSS.css: generate a suitable css file to go with the html
      --fragment:    generate just a html fragment rather than a page
      --plain:       do not use fancy utf8 characters to make arrows prettier
+     --unquote:     do not quote html characters in html diffs
      --www:         send output to a browser
 ````
 
-Formats supported are CSV, TSV, and ndjson.
+Formats supported are CSV, TSV, Sqlite (with `--input-format sqlite` or
+the `.sqlite` extension), and ndjson.
 
 Using with git
 --------------

--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -965,13 +965,14 @@ class Coopy {
                 if (args.length < 1) {
                     io.writeStderr("daff can produce and apply tabular diffs.\n");
                     io.writeStderr("Call as:\n");
+                    io.writeStderr("  daff a.csv b.csv\n");
                     io.writeStderr("  daff [--color] [--no-color] [--output OUTPUT.csv] a.csv b.csv\n");
                     io.writeStderr("  daff [--output OUTPUT.html] a.csv b.csv\n");
-                    io.writeStderr("  daff [--output OUTPUT.csv] parent.csv a.csv b.csv\n");
-                    io.writeStderr("  daff [--output OUTPUT.ndjson] a.ndjson b.ndjson\n");
                     io.writeStderr("  daff [--www] a.csv b.csv\n");
-                    io.writeStderr("  daff patch [--inplace] [--output OUTPUT.csv] a.csv patch.csv\n");
-                    io.writeStderr("  daff merge [--inplace] [--output OUTPUT.csv] parent.csv a.csv b.csv\n");
+                    io.writeStderr("  daff parent.csv a.csv b.csv\n");
+                    io.writeStderr("  daff --input-format sqlite a.db b.db\n");
+                    io.writeStderr("  daff patch [--inplace] a.csv patch.csv\n");
+                    io.writeStderr("  daff merge [--inplace] parent.csv a.csv b.csv\n");
                     io.writeStderr("  daff trim [--output OUTPUT.csv] source.csv\n");
                     io.writeStderr("  daff render [--output OUTPUT.html] diff.csv\n");
                     io.writeStderr("  daff copy in.csv out.tsv\n");
@@ -994,13 +995,13 @@ class Coopy {
                     io.writeStderr("     --id:          specify column to use as primary key (repeat for multi-column key)\n");
                     io.writeStderr("     --ignore:      specify column to ignore completely (can repeat)\n");
                     io.writeStderr("     --index:       include row/columns numbers from original tables\n");
-                    io.writeStderr("     --input-format [csv|tsv|ssv|psv|json]: set format to expect for input\n");
+                    io.writeStderr("     --input-format [csv|tsv|ssv|psv|json|sqlite]: set format to expect for input\n");
                     io.writeStderr("     --eol [crlf|lf|cr|auto]: separator between rows of csv output.\n");
                     io.writeStderr("     --no-color:    make sure terminal colors are not used\n");
                     io.writeStderr("     --ordered:     assume row order is meaningful (default for CSV)\n");
                     io.writeStderr("     --output-format [csv|tsv|ssv|psv|json|copy|html]: set format for output\n");
                     io.writeStderr("     --padding [dense|sparse|smart]: set padding method for aligning columns\n");
-                    io.writeStderr("     --table NAME:  compare the named table, used with SQL sources\n");
+                    io.writeStderr("     --table NAME:  compare the named table, used with SQL sources. If name changes, use 'n1:n2'\n");
                     io.writeStderr("     --unordered:   assume row order is meaningless (default for json formats)\n");
                     io.writeStderr("     -w / --ignore-whitespace: ignore changes in leading/trailing whitespace\n");
                     io.writeStderr("     -i / --ignore-case: ignore differences in case\n");


### PR DESCRIPTION
For large files, daff's sqlite support is handy, but isn't really mentioned anywhere, as pointed out in #127.  This commit advertises the fact a bit more, and particularly the existence of and need for `--input-format sqlite`.  In a future version of daff, it would be good to autodetect sqlite files.