### PR TITLE
do not touch exports without checking that it exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - if ! $USE_PAULFITZ; then sudo apt-get update; fi
 
 install:
-  - sudo apt-get install time php5 sqlite3 -y
+  - sudo apt-get install time php sqlite3 -y
   - if ! $USE_PAULFITZ; then sudo apt-get install haxe -y; fi
   - if $USE_PAULFITZ; then wget https://github.com/paulfitz/haxe/releases/download/rb_v3.1.1_16/haxerb.zip; fi
   - if $USE_PAULFITZ; then unzip -q haxerb.zip; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: xenial
 
 node_js: "4"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - sudo apt-get install gcc-multilib g++-multilib -y  # VM is 64bit but hxcpp builds 32bit
   - mkdir -p ~/haxelib
   - haxelib setup ~/haxelib
-  - if ! $USE_PAULFITZ; then sudo apt-get install mono-mcs time php5-cli; fi
+  - if ! $USE_PAULFITZ; then sudo apt-get install mono-mcs time php-cli; fi
   - if $USE_PAULFITZ; then sudo apt-get install python3; fi
   - if ! $USE_PAULFITZ; then haxelib install hxcpp; fi
   - if ! $USE_PAULFITZ; then haxelib install hxjava; fi

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ ntest_php:
 	find ntest_php_dir/lib/coopy -iname "*View.*.php" -exec sed -i 's/function hashSet(/function hashSet(\&/' {} \;
 	cp env/php/*.class.php ntest_php_dir/lib/coopy/
 	#time hhvm ntest_php_dir/index.php
-	time php5 ntest_php_dir/index.php
+	time php ntest_php_dir/index.php
 	#php5 -d xdebug.profiler_enable=1 -d xdebug.profiler_output_dir=/tmp ntest_php_dir/index.php
 
 ntest_java:
@@ -283,7 +283,7 @@ perf_php:
 	haxe -D enbiggen -php ntest_php_dir -main harness.Main
 	cp env/php/*.class.php ntest_php_dir/lib/coopy/
 	#time hhvm ntest_php_dir/index.php
-	time php5 ntest_php_dir/index.php
+	time php ntest_php_dir/index.php
 
 integration: js py
 	./test/integration_git.sh js

--- a/env/js/fix_exports.js
+++ b/env/js/fix_exports.js
@@ -1,6 +1,6 @@
 
 var daff = null;
-if (exports.coopy) {
+if (typeof exports !== 'undefined' && exports.coopy) {
     // avoid having excess nesting (coopy.coopy) when using node
     for (f in exports.coopy) { 
 	if (exports.coopy.hasOwnProperty(f)) {

--- a/env/js/sqlite_database.js
+++ b/env/js/sqlite_database.js
@@ -134,6 +134,8 @@
 	    return this.fname;
 	}
 
-	exports.SqliteDatabase = SqliteDatabase;
+        if (typeof exports !== 'undefined') {
+            exports.SqliteDatabase = SqliteDatabase;
+        }
 
     })();

--- a/env/js/util.js
+++ b/env/js/util.js
@@ -1,4 +1,4 @@
-if (true) {
+if (typeof exports !== 'undefined') {
     
     var tio = {};
     var tio_args = [];

--- a/harness/Main.hx
+++ b/harness/Main.hx
@@ -40,6 +40,11 @@ class Main {
     }
 
     static public function main() {
+        // php version workaround from https://github.com/HaxeFoundation/hscript/commit/dffa3345d0e2b154efd70251aef03193ae7a95c1
+        #if ((haxe_ver < 4) && php)
+            // uncaught exception: The each() function is deprecated. This message will be suppressed on further calls (errno: 8192)
+            untyped __php__("error_reporting(E_ALL ^ E_DEPRECATED);");
+		#end
         var main = new Main();
         if (!Native.wrap(main)) {
             main.body();


### PR DESCRIPTION
A change to daff to ease its use with webpack broke its use from a browser via direct script inclusion (#131). This commit makes sure that `exports` is available before fiddling with it. 