### PR TITLE
Swaps out the deprecated npm script `prepublish` for `prepublishOnly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fibers": "^1.0.0"
   },
   "scripts": {
-    "prepublish": "make js",
+    "prepublishOnly": "make js",
     "test": "make test"
   },
   "main": "lib/daff.js",


### PR DESCRIPTION
Was getting a deprecation warning as part of putting #137 together, which seems to have a fairly straightforward fix:

> Since npm@1.1.71, the npm CLI has run the prepublish script for both npm publish and npm install, because it’s a convenient way to prepare a package for use (some common use cases are described in the section below). It has also turned out to be, in practice, very confusing. As of npm@4.0.0, a new event has been introduced, prepare, that preserves this existing behavior. A new event, prepublishOnly has been added as a transitional strategy to allow users to avoid the confusing behavior of existing npm versions and only run on npm publish (for instance, running the tests one last time to ensure they’re in good shape).
>
>See https://github.com/npm/npm/issues/10074 for a much lengthier justification, with further reading, for this change.

Reference: https://docs.npmjs.com/misc/scripts#deprecation-note