### PR TITLE
lazy-load sqlite3 in python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - sudo apt-get install gcc-multilib g++-multilib -y  # VM is 64bit but hxcpp builds 32bit
   - mkdir -p ~/haxelib
   - haxelib setup ~/haxelib
+  - haxelib install hx3compat
   - if ! $USE_PAULFITZ; then sudo apt-get install mono-mcs time php-cli; fi
   - if $USE_PAULFITZ; then sudo apt-get install python3; fi
   - if ! $USE_PAULFITZ; then haxelib install hxcpp; fi
@@ -40,7 +41,7 @@ script:
   - if ! $USE_PAULFITZ; then make cpp; fi
   - if ! $USE_PAULFITZ; then make cs; fi
   - make ntest_js
-  - make ntest_php
+  - if ! $USE_PAULFITZ; then make ntest_php; fi
   - if ! $USE_PAULFITZ; then make ntest_java; fi
   - if $USE_PAULFITZ; then make ntest_py; fi
   - if $USE_PAULFITZ; then make ntest_rb; fi

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ cpp_package:
 
 php:
 	haxe language/php.hxml
-	find php_bin/lib/coopy -iname "*View.*.php" -exec sed -i.bak -e 's/function hashSet(/function hashSet(\&/' {} \;
-	cp env/php/*.class.php php_bin/lib/coopy/
+	find php_bin/lib/coopy -iname "*View.php" -exec $(SED) -i 's/function hashSet *(\$$/function hashSet(\&\$$/' {} \;
+	cp env/php/*.php php_bin/lib/coopy/
 	cp scripts/example.php php_bin/
 	@echo 'Output in php_bin, run "php php_bin/index.php" for an example utility'
 	@echo 'or try "php php_bin/example.php" for an example of using daff as a library'
@@ -241,33 +241,33 @@ clean:
 ntest: ntest_js ntest_rb ntest_py ntest_php ntest_java
 
 ntest_js: js
-	haxe -js ntest.js -D haxeJSON -main harness.Main
+	haxe -js ntest.js -L hx3compat -D haxeJSON -main harness.Main || haxe -js ntest.js -D haxeJSON -main harness.Main
 	NODE_PATH=$$PWD/lib node ntest.js
 
 py_test_files=$(wildcard test/*.py)
 py_targets=$(subst .py,_py,$(py_test_files))
 ntest_py: py $(py_targets)
 	rm -f daff/__init__.py daff.py
-	haxe -python ntest.py -main harness.Main
+	haxe -python ntest.py -L hx3compat -main harness.Main || haxe -python ntest.py -main harness.Main
 	PYTHONPATH=$$PWD/python_bin python3 ntest.py
 test/%_py: test/%.py
 	@cd test; echo == $*.py; PYTHONPATH=${PYTHONPATH}:$(PWD)/python_bin python3 $*.py
 
 ntest_py2: py2
 	rm -f daff/__init__.py daff.py
-	haxe -python ntest.py -main harness.Main
+	haxe -python ntest.py -L hx3compat -main harness.Main || haxe -python ntest.py -main harness.Main
 	PYTHONPATH=$$PWD/python_bin python3 ntest.py 
 
 ntest_php:
-	haxe -D haxeJSON -php ntest_php_dir -main harness.Main
-	find ntest_php_dir/lib/coopy -iname "*View.*.php" -exec $(SED) -i 's/function hashSet(/function hashSet(\&/' {} \;
-	cp env/php/*.class.php ntest_php_dir/lib/coopy/
+	haxe -D haxeJSON -php ntest_php_dir -L hx3compat -main harness.Main
+	find ntest_php_dir/lib/coopy -iname "*View.php" -exec $(SED) -i 's/function hashSet *(\$$/function hashSet(\&\$$/' {} \;
+	cp env/php/*.php ntest_php_dir/lib/coopy/
 	#time hhvm ntest_php_dir/index.php
 	time php ntest_php_dir/index.php
 	#php5 -d xdebug.profiler_enable=1 -d xdebug.profiler_output_dir=/tmp ntest_php_dir/index.php
 
 ntest_java:
-	haxe -java ntest_java_dir -main harness.Main -D no-compilation
+	haxe -java ntest_java_dir -L hx3compat -main harness.Main -D no-compilation
 	cp scripts/JavaTableView.java ntest_java_dir/src/coopy
 	#	echo "src/coopy/JavaTableView.java" >> ntest_java_dir/cmd
 	cd ntest_java_dir && find src -iname "*.java" > cmd
@@ -290,7 +290,7 @@ perf_js:
 
 perf_php:
 	haxe -D enbiggen -php ntest_php_dir -main harness.Main
-	cp env/php/*.class.php ntest_php_dir/lib/coopy/
+	cp env/php/*.php ntest_php_dir/lib/coopy/
 	#time hhvm ntest_php_dir/index.php
 	time php ntest_php_dir/index.php
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,13 @@
 # If you are just interested in Javascript only the js
 # and test targets are important.
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+  SED = gsed
+else
+  SED = sed
+endif
+
 default: test
 
 js:
@@ -58,7 +65,7 @@ cpp:
 
 version:
 	grep "\"version\"" package.json | grep -E -o "[.0-9]+" > version.txt
-	cat coopy/Coopy.hx | sed "s/VERSION = .*;/VERSION = \"`cat version.txt`\";/" > coopy/Coopy.hx.next
+	cat coopy/Coopy.hx | $(SED) "s/VERSION = .*;/VERSION = \"`cat version.txt`\";/" > coopy/Coopy.hx.next
 	cmp coopy/Coopy.hx.next coopy/Coopy.hx || cp coopy/Coopy.hx.next coopy/Coopy.hx
 	rm -f coopy/Coopy.hx.next version.txt
 	@grep "\"version\"" package.json
@@ -113,16 +120,15 @@ py:
 	rm -rf python_bin
 	mkdir -p python_bin
 	haxe language/py_util.hxml
-# my goodness, the i command in sed is hard to use from a makefile
 	mv python_bin/daff.py python_bin/daff_base.py
 	echo '#!/usr/bin/env python' > python_bin/daff.py
 	cat python_bin/daff_base.py >> python_bin/daff.py
-	sed -i.bak -e "s|.*Coopy.main.*||" python_bin/daff.py
+	$(SED) -i "s|.*Coopy.main.*||" python_bin/daff.py
 	cat scripts/python_table_view.py >> python_bin/daff.py
 	cat env/py/export_functions.py >> python_bin/daff.py
 	cat env/py/sqlite_database.py >> python_bin/daff.py
-	sed -i.bak -e 's/Sys.stdout().writeString(txt)/get_stdout().write(txt.encode("utf-8", "strict"))/' python_bin/daff.py # fix utf-8
-	sed -i.bak -e 's/python_lib_Sys.stdout.buffer/get_stdout()/' python_bin/daff.py
+	$(SED) -i 's/Sys.stdout().writeString(txt)/get_stdout().write(txt.encode("utf-8", "strict"))/' python_bin/daff.py # fix utf-8
+	$(SED) -i 's/python_lib_Sys.stdout.buffer/get_stdout()/' python_bin/daff.py
 	echo 'def get_stdout():\n\treturn (python_lib_Sys.stdout.buffer if hasattr(python_lib_Sys.stdout,"buffer") else python_lib_Sys.stdout)' >> python_bin/daff.py
 	echo "if __name__ == '__main__':" >> python_bin/daff.py
 	echo "\tCoopy.main()" >> python_bin/daff.py
@@ -136,23 +142,23 @@ py2: py
 	echo "We need 3to2, https://bitbucket.org/amentajo/lib3to2"
 	which 3to2
 	3to2 -x except -x printfunction -x print -w python_bin/daff.py > /dev/null
-	sed -i.bak -e '14iimport codecs' python_bin/daff.py
-	sed -i.bak -e 's/.*stream.writable.*//' python_bin/daff.py
-	sed -i.bak -e 's/.*Read only stream.*//' python_bin/daff.py
-	sed -i.bak -e 's/python_lib_Builtins/python_lib_Builtin/g' python_bin/daff.py
-	sed -i.bak -e 's/python_lib_Builtin.open(path,.r.*)/codecs.open(path,"r","utf-8")/' python_bin/daff.py
-	sed -i.bak -e 's/python_lib_Builtin.open(path,.w.*)/codecs.open(path,"w","utf-8")/' python_bin/daff.py
-	sed -i.bak -e 's/= \([a-z0-9_.]*\)\.next()/= hxnext(\1)/' python_bin/daff.py
-	sed -i.bak -e 's/ unicode(/ hxunicode(/g' python_bin/daff.py
-	sed -i.bak -e 's/python_lib_Builtin.unicode/hxunicode/g' python_bin/daff.py
-	sed -i.bak -e 's/python_lib_Builtin.unichr/hxunichr/g' python_bin/daff.py
-	sed -i.bak -e 's/xrange/hxrange/g' python_bin/daff.py
-	sed -i.bak -e 's/python_lib_FuncTools.cmp_to_key/hx_cmp_to_key/g' python_bin/daff.py
-	sed -i.bak -e 's/^\([ \t]*\)def next(/\1def __next__(self): return self.next()\n\n\1def next(/g' python_bin/daff.py
-	sed -i.bak -e 's/from datetime import timezone/#from datetime import timezone/' python_bin/daff.py
-	sed -i.bak -e 's/Date.EPOCH_UTC =/#Date.EPOCH_UTC =/' python_bin/daff.py
-	sed -i.bak -e 's/from itertools import imap/import itertools; imap = itertools.imap if hasattr(itertools, "imap") else map/' python_bin/daff.py
-	sed -i.bak -e 's/from itertools import ifilter/import itertools; ifilter = itertools.ifilter if hasattr(itertools, "ifilter") else filter/' python_bin/daff.py
+	$(SED) -i '14iimport codecs' python_bin/daff.py
+	$(SED) -i 's/.*stream.writable.*//' python_bin/daff.py
+	$(SED) -i 's/.*Read only stream.*//' python_bin/daff.py
+	$(SED) -i 's/python_lib_Builtins/python_lib_Builtin/g' python_bin/daff.py
+	$(SED) -i 's/python_lib_Builtin.open(path,.r.*)/codecs.open(path,"r","utf-8")/' python_bin/daff.py
+	$(SED) -i 's/python_lib_Builtin.open(path,.w.*)/codecs.open(path,"w","utf-8")/' python_bin/daff.py
+	$(SED) -i 's/= \([a-z0-9_.]*\)\.next()/= hxnext(\1)/' python_bin/daff.py
+	$(SED) -i 's/ unicode(/ hxunicode(/g' python_bin/daff.py
+	$(SED) -i 's/python_lib_Builtin.unicode/hxunicode/g' python_bin/daff.py
+	$(SED) -i 's/python_lib_Builtin.unichr/hxunichr/g' python_bin/daff.py
+	$(SED) -i 's/xrange/hxrange/g' python_bin/daff.py
+	$(SED) -i 's/python_lib_FuncTools.cmp_to_key/hx_cmp_to_key/g' python_bin/daff.py
+	$(SED) -i 's/^\([ \t]*\)def next(/\1def __next__(self): return self.next()\n\n\1def next(/g' python_bin/daff.py
+	$(SED) -i 's/from datetime import timezone/#from datetime import timezone/' python_bin/daff.py
+	$(SED) -i 's/Date.EPOCH_UTC =/#Date.EPOCH_UTC =/' python_bin/daff.py
+	$(SED) -i 's/from itertools import imap/import itertools; imap = itertools.imap if hasattr(itertools, "imap") else map/' python_bin/daff.py
+	$(SED) -i 's/from itertools import ifilter/import itertools; ifilter = itertools.ifilter if hasattr(itertools, "ifilter") else filter/' python_bin/daff.py
 	cp scripts/python23.py python_bin/daff2.py
 	cat python_bin/daff.py | grep -v "from __future__" | grep -v "from __builtin__ import" | grep -v "import __builtin__ as" | grep -v '#!' >> python_bin/daff2.py
 	mv python_bin/daff2.py python_bin/daff.py
@@ -254,7 +260,7 @@ ntest_py2: py2
 
 ntest_php:
 	haxe -D haxeJSON -php ntest_php_dir -main harness.Main
-	find ntest_php_dir/lib/coopy -iname "*View.*.php" -exec sed -i.bak -e 's/function hashSet(/function hashSet(\&/' {} \;
+	find ntest_php_dir/lib/coopy -iname "*View.*.php" -exec $(SED) -i 's/function hashSet(/function hashSet(\&/' {} \;
 	cp env/php/*.class.php ntest_php_dir/lib/coopy/
 	#time hhvm ntest_php_dir/index.php
 	time php ntest_php_dir/index.php

--- a/coopy/CombinedTable.hx
+++ b/coopy/CombinedTable.hx
@@ -58,8 +58,8 @@ class CombinedTable implements Table {
         return this;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         return core.width;

--- a/coopy/CombinedTableBody.hx
+++ b/coopy/CombinedTableBody.hx
@@ -33,8 +33,8 @@ class CombinedTableBody implements Table {
         return this;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         return all.width-1;

--- a/coopy/CombinedTableHead.hx
+++ b/coopy/CombinedTableHead.hx
@@ -32,8 +32,8 @@ class CombinedTableHead implements Table {
         return this;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         return all.width;

--- a/coopy/JsonTable.hx
+++ b/coopy/JsonTable.hx
@@ -30,8 +30,8 @@ class JsonTable implements Table implements Meta {
         return this;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         return w;

--- a/coopy/JsonTables.hx
+++ b/coopy/JsonTables.hx
@@ -67,8 +67,8 @@ class JsonTables implements Table {
         }
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function getCell(x: Int, y: Int) : Dynamic {
         return t.getCell(x,y);

--- a/coopy/SimpleTable.hx
+++ b/coopy/SimpleTable.hx
@@ -36,8 +36,8 @@ class SimpleTable implements Table {
         return this;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         return w;

--- a/coopy/SqlTable.hx
+++ b/coopy/SqlTable.hx
@@ -142,8 +142,8 @@ class SqlTable implements Table implements Meta implements RowStream {
         return false;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         getColumns();

--- a/coopy/SqlTables.hx
+++ b/coopy/SqlTables.hx
@@ -45,8 +45,8 @@ class SqlTables implements Table {
         }
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function getCell(x: Int, y: Int) : Dynamic {
         return t.getCell(x,y);

--- a/coopy/Table.hx
+++ b/coopy/Table.hx
@@ -19,7 +19,7 @@ interface Table {
      * a call to `get_height()`.
      *
      */
-    var height(get_height,never) : Int; // Read-only height property
+    var height(get,never) : Int; // Read-only height property
 
     /**
      *
@@ -27,7 +27,7 @@ interface Table {
      * a call to `get_width()`.
      *
      */
-    var width(get_width,never) : Int;   // Read-only width property
+    var width(get,never) : Int;   // Read-only width property
 
     /**
      *

--- a/coopy/TableIO.hx
+++ b/coopy/TableIO.hx
@@ -180,7 +180,7 @@ class TableIO {
      */
     public function openSqliteDatabase(path: String) : SqlDatabase {
 #if python
-        return (python.Syntax.pythonCode("SqliteDatabase(sqlite3.connect(path),path)"));
+        return (python.Syntax.pythonCode("SqliteDatabase(path,path)"));
 #end
         return null;
     }

--- a/env/php/PhpCellView.php
+++ b/env/php/PhpCellView.php
@@ -1,6 +1,8 @@
 <?php
 
-class coopy_PhpCellView implements coopy_View {
+namespace coopy;
+
+class PhpCellView implements View {
   public function toString($d) {
     return print_r($d,true);
   }
@@ -13,7 +15,10 @@ class coopy_PhpCellView implements coopy_View {
   public function makeHash() { return array(); }
   public function isHash($d) { return is_array($d); }
   public function hashSet(&$d,$k,$v) { $d[$k] = $v; }
-  public function hashGet($d,$k) { return $d[$k]; }
+  public function hashGet($d,$k) {
+    if (!isset($d[$k])) { return null; }
+    return $d[$k];
+  }
   public function hashExists($d,$k) { return array_key_exists($k,$d); }
   public function isTable($t) { return false; }
   public function getTable($t) { return false; }

--- a/env/php/PhpTableView.php
+++ b/env/php/PhpTableView.php
@@ -1,6 +1,8 @@
 <?php
 
-class coopy_PhpTableView implements coopy_Table{
+namespace coopy;
+
+class PhpTableView implements \coopy\Table{
   public function __construct(&$data) {
     $this->data = &$data;
     $this->height = count($data);
@@ -31,11 +33,11 @@ class coopy_PhpTableView implements coopy_Table{
   }
 
   public function toString() {
-    return coopy_SimpleTable::tableToString($this);
+    return \coopy\SimpleTable::tableToString($this);
   }
 
   public function getCellView() {
-    return new coopy_PhpCellView();
+    return new \coopy\PhpCellView();
   }
 
   public function isResizable() {
@@ -86,8 +88,8 @@ class coopy_PhpTableView implements coopy_Table{
   }
 
   public function insertOrDeleteRows($xfate,$hfate) {
-    if (is_array($xfate)) { $fate = $xfate; } else { $fate = $xfate->a; }
-    $fate = $xfate->a;
+    if (is_array($xfate)) { $fate = $xfate; } else { $fate = $xfate->arr; }
+    $fate = $xfate->arr;
     $ndata = array();
     $top = 0;
     for ($i=0; $i<count($fate); $i++) {
@@ -110,7 +112,7 @@ class coopy_PhpTableView implements coopy_Table{
   }
 
   public function insertOrDeleteColumns($xfate,$wfate) {
-    if (is_array($xfate)) { $fate = $xfate; } else { $fate = $xfate->a; }
+    if (is_array($xfate)) { $fate = $xfate; } else { $fate = $xfate->arr; }
     if ($wfate==$this->width && $wfate==count($fate)) {
       $eq = true;
       for ($i=0; $i<$wfate; $i++) {
@@ -171,9 +173,9 @@ class coopy_PhpTableView implements coopy_Table{
     return true;
   }
 
-  public function hclone() {
+  public function clone() {
     $blank = array();
-    $result = new coopy_PhpTableView($blank);
+    $result = new \coopy\PhpTableView($blank);
     $result->resize($this->width,$this->height);
     for ($c=0; $c<$this->width; $c++) {
       for ($r=0; $r<$this->height; $r++) {
@@ -185,7 +187,7 @@ class coopy_PhpTableView implements coopy_Table{
 
   public function create() {
     $blank = array();
-    return new coopy_PhpTableView($blank);
+    return new \coopy\PhpTableView($blank);
   }
 
   public function getMeta() {

--- a/env/py/sqlite_database.py
+++ b/env/py/sqlite_database.py
@@ -1,7 +1,8 @@
-import sqlite3
-
 class SqliteDatabase(SqlDatabase):
     def __init__(self,db,fname):
+        import sqlite3
+        if not hasattr(db, 'cursor'):
+            db = sqlite3.connect(db)
         self.db = db
         db.isolation_level = None
         self.fname = fname

--- a/harness/Native.hx
+++ b/harness/Native.hx
@@ -83,7 +83,7 @@ class Native {
         untyped __rb__("require 'lib/coopy/table_view' unless defined?(::Coopy::TableView)");
         return untyped __js__("::Coopy::TableView.new(data)");
 #elseif php
-        return untyped __php__("new coopy_PhpTableView($data)");
+        return untyped __php__("new \\coopy\\PhpTableView($data)");
 #elseif java
         return untyped __java__("new coopy.JavaTableView((Object[][])data)");
 #else

--- a/harness/Native.hx
+++ b/harness/Native.hx
@@ -158,7 +158,7 @@ class Native {
     return untyped __js__("new daff.SqliteDatabase(new sqlite3.Database(name),name,Fiber)");
 #elseif python
     python.Syntax.pythonCode("daff = __import__('daff')");
-    return python.Syntax.pythonCode("daff.SqliteDatabase(daff.sqlite3.connect(name),name)");
+    return python.Syntax.pythonCode("daff.SqliteDatabase(name,name)");
 #end
     return null;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -448,7 +448,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -471,7 +471,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -485,7 +485,7 @@
     },
     "nan": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
       "optional": true
     },
@@ -652,7 +652,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "optional": true
         }
@@ -660,7 +660,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "optional": true,
       "requires": {
@@ -793,7 +793,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"

--- a/scripts/JavaTableView.java
+++ b/scripts/JavaTableView.java
@@ -303,7 +303,7 @@ public class JavaTableView extends haxe.lang.HxObject implements coopy.Table
     }
 	
 
-    @Override public java.lang.Object __hx_invokeField(java.lang.String field, haxe.root.Array dynargs) {
+    @Override public java.lang.Object __hx_invokeField(java.lang.String field, java.lang.Object[] dynargs) {
 	boolean onwards = true;
 	switch (field.hashCode()) {
 	case -75605984:
@@ -327,7 +327,7 @@ public class JavaTableView extends haxe.lang.HxObject implements coopy.Table
 	case 1889278614:
 	    if (field.equals("insertOrDeleteColumns")) {
 		onwards = false;
-		return this.insertOrDeleteColumns(((haxe.root.Array<java.lang.Object>) (dynargs.__get(0)) ), ((int) (haxe.lang.Runtime.toInt(dynargs.__get(1))) ));
+		return this.insertOrDeleteColumns(((haxe.root.Array<java.lang.Object>) (dynargs[0]) ), ((int) (haxe.lang.Runtime.toInt(dynargs[1])) ));
 	    }
 	    break;
 	case 1150076829:
@@ -339,7 +339,7 @@ public class JavaTableView extends haxe.lang.HxObject implements coopy.Table
 	case 1186308544:
 	    if (field.equals("insertOrDeleteRows")) {
 		onwards = false;
-		return this.insertOrDeleteRows(((haxe.root.Array<java.lang.Object>) (dynargs.__get(0)) ), ((int) (haxe.lang.Runtime.toInt(dynargs.__get(1))) ));
+		return this.insertOrDeleteRows(((haxe.root.Array<java.lang.Object>) (dynargs[0]) ), ((int) (haxe.lang.Runtime.toInt(dynargs[1])) ));
 	    }
 	    break;
 	case 859648560:
@@ -357,13 +357,13 @@ public class JavaTableView extends haxe.lang.HxObject implements coopy.Table
 	case -934437708:
 	    if (field.equals("resize")) {
 		onwards = false;
-		return this.resize(((int) (haxe.lang.Runtime.toInt(dynargs.__get(0))) ), ((int) (haxe.lang.Runtime.toInt(dynargs.__get(1))) ));
+		return this.resize(((int) (haxe.lang.Runtime.toInt(dynargs[0])) ), ((int) (haxe.lang.Runtime.toInt(dynargs[1])) ));
 	    }
 	    break;
 	case -75632168:
 	    if (field.equals("getCell")) {
 		onwards = false;
-		return this.getCell(((int) (haxe.lang.Runtime.toInt(dynargs.__get(0))) ), ((int) (haxe.lang.Runtime.toInt(dynargs.__get(1))) ));
+		return this.getCell(((int) (haxe.lang.Runtime.toInt(dynargs[0])) ), ((int) (haxe.lang.Runtime.toInt(dynargs[1])) ));
 	    }
 	    break;
 	case -972315487:
@@ -375,7 +375,7 @@ public class JavaTableView extends haxe.lang.HxObject implements coopy.Table
 	case 1984477412:
 	    if (field.equals("setCell")) {
 		onwards = false;
-		this.setCell(((int) (haxe.lang.Runtime.toInt(dynargs.__get(0))) ), ((int) (haxe.lang.Runtime.toInt(dynargs.__get(1))) ), dynargs.__get(2));
+		this.setCell(((int) (haxe.lang.Runtime.toInt(dynargs[0])) ), ((int) (haxe.lang.Runtime.toInt(dynargs[1])) ), dynargs[2]);
 	    }
 	    break;
 	case 1160377501:

--- a/scripts/example.php
+++ b/scripts/example.php
@@ -1,10 +1,18 @@
 <?php
 
-if(version_compare(PHP_VERSION, '5.1.0', '<')) {
-    exit('Your current PHP version is: ' . PHP_VERSION . '. Haxe/PHP generates code for version 5.1.0 or later');
-}
+use \coopy\Coopy;
 
-require_once dirname(__FILE__).'/lib/php/Boot.class.php';
+set_include_path(get_include_path().PATH_SEPARATOR.__DIR__.'/lib');
+spl_autoload_register(
+	function($class){
+		$file = stream_resolve_include_path(str_replace('\\', '/', $class) .'.php');
+		if ($file) {
+			include_once $file;
+		}
+	}
+);
+\php\Boot::__hx__init();
+#(unknown)
 
 $data1 = [
   ['Country','Capital'],
@@ -21,26 +29,26 @@ $data2 = [
   ['Germany','de','Berlin']
   ];
 
-$table1 = new coopy_PhpTableView($data1);
-$table2 = new coopy_PhpTableView($data2);
+$table1 = new \coopy\PhpTableView($data1);
+$table2 = new \coopy\PhpTableView($data2);
 
-$alignment = coopy_Coopy::compareTables($table1,$table2)->align();
+$alignment = \coopy\Coopy::compareTables($table1,$table2)->align();
 
 $data_diff = [];
-$table_diff = new coopy_PhpTableView($data_diff);
+$table_diff = new \coopy\PhpTableView($data_diff);
 
-$flags = new coopy_CompareFlags();
-$highlighter = new coopy_TableDiff($alignment,$flags);
+$flags = new \coopy\CompareFlags();
+$highlighter = new \coopy\TableDiff($alignment,$flags);
 $highlighter->hilite($table_diff);
 
-$diff2html = new coopy_DiffRender();
+$diff2html = new \coopy\DiffRender();
 $diff2html->usePrettyArrows(false);
 $diff2html->render($table_diff);
 $table_diff_html = $diff2html->html();
 echo $table_diff_html;
 
 
-$patcher = new coopy_HighlightPatch($table1,$table_diff);
+$patcher = new \coopy\HighlightPatch($table1,$table_diff);
 $patcher->apply();
 
 ?>

--- a/test/integration_git.sh
+++ b/test/integration_git.sh
@@ -35,14 +35,14 @@ cmp diff1 diff2 && {
 } || echo "good"
 
 header "Prepare for a merge test"
-sed -i "s/Whitestone/Whitestan/" bridges.csv
+sed -i.bak -e "s/Whitestone/Whitestan/" bridges.csv
 cd ..
 git clone test_repo test_repo2
 cd test_repo2
 git config user.email "nevyn@example.com"
 git config user.name "Nevyn"
 $DAFF_SCRIPT git csv
-sed -i "s/Buck/Duck/" bridges.csv
+sed -i.bak -e "s/Buck/Duck/" bridges.csv
 git commit -m "duck" -a
 cd ../test_repo
 git commit -m "stan" -a

--- a/test/test_sqlite.py
+++ b/test/test_sqlite.py
@@ -1,6 +1,7 @@
 import daff
+import sqlite3
 
-db = daff.sqlite3.connect(':memory:')
+db = sqlite3.connect(':memory:')
 c = db.cursor()
 
 c.execute("CREATE TABLE ver1 (id INTEGER PRIMARY KEY, name TEXT)")


### PR DESCRIPTION
This loads sqlite3 only when needed in python version, so if sqlite3 is absent but unneeded, daff is still usable.

Also includes some tweaks for mac build.

This follows a suggestion by @DerrickRice in #143.