### PR TITLE
Fix Haxe 4.0.5 syntax error about Custom property accessor

### DIFF
--- a/coopy/CombinedTable.hx
+++ b/coopy/CombinedTable.hx
@@ -58,8 +58,8 @@ class CombinedTable implements Table {
         return this;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         return core.width;

--- a/coopy/CombinedTableBody.hx
+++ b/coopy/CombinedTableBody.hx
@@ -33,8 +33,8 @@ class CombinedTableBody implements Table {
         return this;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         return all.width-1;

--- a/coopy/CombinedTableHead.hx
+++ b/coopy/CombinedTableHead.hx
@@ -32,8 +32,8 @@ class CombinedTableHead implements Table {
         return this;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         return all.width;

--- a/coopy/JsonTable.hx
+++ b/coopy/JsonTable.hx
@@ -30,8 +30,8 @@ class JsonTable implements Table implements Meta {
         return this;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         return w;

--- a/coopy/JsonTables.hx
+++ b/coopy/JsonTables.hx
@@ -67,8 +67,8 @@ class JsonTables implements Table {
         }
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function getCell(x: Int, y: Int) : Dynamic {
         return t.getCell(x,y);

--- a/coopy/SimpleTable.hx
+++ b/coopy/SimpleTable.hx
@@ -36,8 +36,8 @@ class SimpleTable implements Table {
         return this;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         return w;

--- a/coopy/SqlTable.hx
+++ b/coopy/SqlTable.hx
@@ -142,8 +142,8 @@ class SqlTable implements Table implements Meta implements RowStream {
         return false;
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function get_width() : Int {
         getColumns();

--- a/coopy/SqlTables.hx
+++ b/coopy/SqlTables.hx
@@ -45,8 +45,8 @@ class SqlTables implements Table {
         }
     }
 
-    public var height(get_height,never) : Int;
-    public var width(get_width,never) : Int;
+    public var height(get,never) : Int;
+    public var width(get,never) : Int;
 
     public function getCell(x: Int, y: Int) : Dynamic {
         return t.getCell(x,y);

--- a/coopy/Table.hx
+++ b/coopy/Table.hx
@@ -19,7 +19,7 @@ interface Table {
      * a call to `get_height()`.
      *
      */
-    var height(get_height,never) : Int; // Read-only height property
+    var height(get,never) : Int; // Read-only height property
 
     /**
      *
@@ -27,7 +27,7 @@ interface Table {
      * a call to `get_width()`.
      *
      */
-    var width(get_width,never) : Int;   // Read-only width property
+    var width(get,never) : Int;   // Read-only width property
 
     /**
      *


### PR DESCRIPTION
Fix Haxe 4.0.5 syntax error:
width/height Custom property accessor is no longer supported, please use `get`