### PR TITLE
support an --ignore-epsilon flag that ignores small floating point diffs

### DIFF
--- a/coopy/CompareFlags.hx
+++ b/coopy/CompareFlags.hx
@@ -204,6 +204,17 @@ class CompareFlags {
 
     /**
      *
+     * If set to a positive number, then cells that looks like floating point
+     * numbers are treated as equal if they are within epsilon of each other.
+     * This option does NOT affect the alignment of rows, so if a floating point
+     * number is part of your table's primary key, this option will not help.
+     * Defaults to a negative number (so it is disabled).
+     *
+     */
+    public var ignore_epsilon : Float;
+
+    /**
+     *
      * Format to use for terminal output.  "plain" for plain text,
      * "ansi", for ansi color codes, null to autodetect.  Defaults to
      * autodetect.
@@ -248,6 +259,7 @@ class CompareFlags {
         count_like_a_spreadsheet = true;
         ignore_whitespace = false;
         ignore_case = false;
+        ignore_epsilon = -1;
         terminal_format = null;
         use_glyphs = true;
         quote_html = true;

--- a/coopy/Coopy.hx
+++ b/coopy/Coopy.hx
@@ -888,6 +888,16 @@ class Coopy {
                     flags.ignore_case = true;
                     args.splice(i,1);
                     break;
+                } else if (tag=="-d" || tag=="--ignore-epsilon") {
+                    more = true;
+                    var eps = args[i+1];
+                    flags.ignore_epsilon = Std.parseFloat(eps);
+                    if (Math.isNaN(flags.ignore_epsilon)) {
+                        io.writeStderr("Epsilon for numeric comparison must be numeric\n");
+                        return 1;
+                    }
+                    args.splice(i,2);
+                    break;
                 } else if (tag=="--padding") {
                     more = true;
                     flags.padding_strategy = args[i+1];
@@ -1005,6 +1015,7 @@ class Coopy {
                     io.writeStderr("     --unordered:   assume row order is meaningless (default for json formats)\n");
                     io.writeStderr("     -w / --ignore-whitespace: ignore changes in leading/trailing whitespace\n");
                     io.writeStderr("     -i / --ignore-case: ignore differences in case\n");
+                    io.writeStderr("     -d EPS / --ignore-epsilon EPS: ignore small floating point differences\n");
                     io.writeStderr("\n");
                     io.writeStderr("  daff render [--output OUTPUT.html] [--css CSS.css] [--fragment] [--plain] diff.csv\n");
                     io.writeStderr("     --css CSS.css: generate a suitable css file to go with the html\n");

--- a/coopy/TableDiff.hx
+++ b/coopy/TableDiff.hx
@@ -690,6 +690,19 @@ class TableDiff {
     }
 
     private function isEqual(v: View, aa: Dynamic, bb: Dynamic) : Bool {
+        // Check if we need to apply an exception for comparing floating
+        // point numbers.
+        if (flags.ignore_epsilon > 0) {
+            var fa = Std.parseFloat(aa);
+            if (!Math.isNaN(fa)) {
+                var fb = Std.parseFloat(bb);
+                if (!Math.isNaN(fb)) {
+                    if (Math.abs(fa - fb) < flags.ignore_epsilon) {
+                        return true;
+                    }
+                }
+            }
+        }
         if (flags.ignore_whitespace || flags.ignore_case) {
             return normalizeString(v,aa) == normalizeString(v,bb);
         }

--- a/harness/EqualityTest.hx
+++ b/harness/EqualityTest.hx
@@ -7,6 +7,7 @@ class EqualityTest extends haxe.unit.TestCase {
     var data2 : Array<Array<Dynamic>>;
     var data3 : Array<Array<Dynamic>>;
     var data4 : Array<Array<Dynamic>>;
+    var data5 : Array<Array<Dynamic>>;
 
     override public function setup() {
         data1 = [['Country','Capital'],
@@ -25,6 +26,10 @@ class EqualityTest extends haxe.unit.TestCase {
                  ['IRELAND','DUBlin'],
                  ['France',15],
                  ['SPAIN','BARCELONA']];
+        data5 = [['COUNTRY','Capital'],
+                 ['IRELAND','DUBlin'],
+                 ['France',15.001],
+                 ['SPAIN','BARCELONA']];
     }
 
     public function testWhiteSpace(){
@@ -40,6 +45,26 @@ class EqualityTest extends haxe.unit.TestCase {
         var table3 = Native.table(data3);
         o = coopy.Coopy.diff(table1,table3,flags);
         assertEquals(2,o.height);
+    }
+
+    public function testEpsilon(){
+        var table4= Native.table(data4);
+        var table5 = Native.table(data5);
+        var flags = new coopy.CompareFlags();
+        flags.ignore_epsilon = 0.01;
+        flags.unchanged_context = 0;
+        var o = coopy.Coopy.diff(table4,table5,flags);
+        assertEquals(1,o.height);
+        flags.ignore_epsilon = 0.0001;
+        o = coopy.Coopy.diff(table4,table5,flags);
+        assertEquals(2,o.height);
+        assertEquals(""+o.getCell(2,1),"15->15.001");
+        o = coopy.Coopy.diff(table5,table4,flags);
+        assertEquals(2,o.height);
+        assertEquals(""+o.getCell(2,1),"15.001->15");
+        flags.ignore_epsilon = 0.01;
+        o = coopy.Coopy.diff(table5,table4,flags);
+        assertEquals(1,o.height);
     }
 
     public function testCase(){


### PR DESCRIPTION
This applies only to cells outside of the table's primary key.  Requested in #155.