### PR TITLE
encode as utf-8 when sending to browser in python

### DIFF
--- a/coopy/TableIO.hx
+++ b/coopy/TableIO.hx
@@ -192,8 +192,8 @@ class TableIO {
         // on the OS to clean it up in its own good time (typically on reboot).
         // TODO: replicate JS version in env/js/util.js that avoids need for
         // temporary file.
-        var f = python.Syntax.code("__import__('tempfile').NamedTemporaryFile('w', delete=False, suffix='.html')");
-        python.Syntax.code("f.write(html)");
+        var f = python.Syntax.code("__import__('tempfile').NamedTemporaryFile('wb', delete=False, suffix='.html')");
+        python.Syntax.code("f.write(html.encode('utf-8', 'strict'))");
         python.Syntax.code("f.close()");
         python.Syntax.code("__import__('webbrowser').open('file://' + f.name)");
 #else


### PR DESCRIPTION
Testing on python2 (still) and python3, this appears to fix the issue in https://github.com/paulfitz/daff/issues/124#issuecomment-668882028