### PR TITLE
Set the version in the POM file before building the package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ java:
 	mv java_bin/java java_bin/daff/src/main
 	cp packaging/java/pom.xml java_bin/daff
 	cp scripts/Example.java java_bin
-	cd java_bin/daff; mvn -Drevision=$(version) clean package
+	cd java_bin/daff; mvn build-helper:parse-version versions:set -DnewVersion=$(version) versions:commit; mvn clean package
 	cd java_bin; javac -cp daff/target/daff-$(version).jar Example.java
 	@echo 'Output in java_bin/daff/target, run "java -jar java_bin/daff/target/daff-$(version).jar" for help'
 	@echo 'Run example with "java -cp java_bin/daff/target/daff-$(version).jar:java_bin Example"'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,12 +3,12 @@
 In order to publish `daff` to Maven Central, the file `~/.jreleaser/config.properties` with the following contents is required:
 
 ```bash
-JRELEASER_NEXUS2_USERNAME="<your-sonatype-account-username>"
-JRELEASER_NEXUS2_PASSWORD="<your-sonatype-account-password>"
-JRELEASER_GPG_PASSPHRASE="<your-pgp-passphrase>"
-JRELEASER_GPG_PUBLIC_KEY="/path/to/public.gpg"
-JRELEASER_GPG_SECRET_KEY="/path/to/private.gpg"
-JRELEASER_GITHUB_TOKEN="<your-github-token>"
+JRELEASER_NEXUS2_USERNAME=<your-sonatype-account-username>
+JRELEASER_NEXUS2_PASSWORD=<your-sonatype-account-password>
+JRELEASER_GPG_PASSPHRASE=<your-pgp-passphrase>
+JRELEASER_GPG_PUBLIC_KEY=/path/to/public.gpg
+JRELEASER_GPG_SECRET_KEY=/path/to/private.gpg
+JRELEASER_GITHUB_TOKEN=<your-github-token>
 ```
 
 In order to get a Sonatype account, follow [the steps in this guide](https://maciejwalkowiak.com/blog/guide-java-publish-to-maven-central/).
@@ -28,30 +28,22 @@ gpg --output private.gpg --armor --export-secret-key username@email-host
 
 The GitHub token can be generated in GitHub/User Profile/Settings/Developer settings.
 
-Once all configuration is in place, execute the following commands.
-
-In the repository root:
-
-```bash
-export version=$(grep "\"version\"" package.json | grep -E -o "[.0-9]+")
-```
-
- In the directory `java_bin/daff` (from JReleaser's [docs](https://jreleaser.org/guide/latest/examples/maven/maven-central.html)):
+Once all configuration is in place, execute the following commands from the directory `java_bin/daff` (from JReleaser's [docs](https://jreleaser.org/guide/latest/examples/maven/maven-central.html)):
 
 1) Verify release & deploy configuration
 
 ```bash
-mvn -Drevision=$version jreleaser:config
+mvn jreleaser:config
 ```
 
 2) Stage all artifacts to a local directory
 
 ```bash
-mvn -Drevision=$version -Ppublication
+mvn -Ppublication
 ```
 
 3) Deploy and release
 
 ```bash
-mvn -Drevision=$version jreleaser:full-release
+mvn jreleaser:full-release
 ```

--- a/packaging/java/pom.xml
+++ b/packaging/java/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.paulfitz</groupId>
     <artifactId>daff</artifactId>
-    <version>${revision}</version>
+    <version>0.0.0</version>
     <packaging>jar</packaging>
 
     <name>daff</name>
@@ -42,6 +42,11 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
The project version in the current POM file contains a placeholder that is replaced during Maven's execution. However, Maven repositories read the version from the POM file. 

This PR reads the version from package.json and updates the version in the POM file. Afterwards the build process and the deployment can proceed as usual.

The instructions for deploying, found in RELEASE.md, were correspondingly updated.