### PR TITLE
prepare to use node:sqlite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [23]
+        node: [18, 23]
 
     steps:
       - name: Checkout repository
@@ -35,6 +35,16 @@ jobs:
 
       - name: Install Node.js dependencies
         run: npm install
+
+      - name: Conditionally install better-sqlite3 for Node < 23
+        run: |
+          NODE_VERSION=$(node -v | sed 's/v\([0-9]*\).*/\1/')
+          if [ "$NODE_VERSION" -lt 23 ]; then
+            echo "Installing better-sqlite3 for Node.js v$NODE_VERSION"
+            npm install better-sqlite3
+          else
+            echo "Skipping better-sqlite3 for Node.js v$NODE_VERSION"
+          fi
 
       - name: Build
         run: make js

--- a/coopy/SqlDatabase.hx
+++ b/coopy/SqlDatabase.hx
@@ -10,6 +10,7 @@ interface SqlDatabase {
     function getQuotedTableName(name: SqlTableName) : String;
     function getQuotedColumnName(name: String) : String;
 
+    function exec(query: String, ?args: Array<Dynamic>): Bool;
     function begin(query: String, ?args: Array<Dynamic>,
                    ?order: Array<String>) : Bool;
     function beginRow(name: SqlTableName, row: Int, ?order: Array<String>) : Bool;

--- a/coopy/SqliteHelper.hx
+++ b/coopy/SqliteHelper.hx
@@ -67,11 +67,10 @@ class SqliteHelper implements SqlHelper {
             q += " IS ?";
             lst.push(conds.get(k));
         }
-        if (!db.begin(q,lst,[])) {
+        if (!db.exec(q,lst)) {
             trace("Problem with database update");
             return false;
         }
-        db.end();
         return true;
     }
 
@@ -86,11 +85,10 @@ class SqliteHelper implements SqlHelper {
             q += " = ?";
             lst.push(conds.get(k));
         }
-        if (!db.begin(q,lst,[])) {
+        if (!db.exec(q,lst)) {
             trace("Problem with database delete");
             return false;
         }
-        db.end();
         return true;
     }
 
@@ -114,11 +112,10 @@ class SqliteHelper implements SqlHelper {
             need_comma = true;
         }
         q += ")";
-        if (!db.begin(q,lst,[])) {
+        if (!db.exec(q,lst)) {
             trace("Problem with database insert");
             return false;
         }
-        db.end();
         return true;
     }
 
@@ -150,7 +147,7 @@ class SqliteHelper implements SqlHelper {
             db.end();
         }
 
-        if (!db.begin("ATTACH ? AS `" + tag + "`",[resource_name],[])) {
+        if (!db.exec("ATTACH ? AS `" + tag + "`",[resource_name])) {
             trace("Failed to attach " + resource_name + " as " + tag);
             return false;
         }
@@ -164,8 +161,8 @@ class SqliteHelper implements SqlHelper {
 
     private function fetchSchema(db: SqlDatabase, name: SqlTableName) : String {
         var tname = db.getQuotedTableName(name);
-        var query = "select sql from sqlite_master where name = " + tname;
-        if (!db.begin(query,null,["sql"])) {
+        var query = "select sql from sqlite_master where name = ?";
+        if (!db.begin(query,[name.toString()],["sql"])) {
             trace("Cannot find schema for table " + tname);
             return null;
         }
@@ -246,11 +243,10 @@ class SqliteHelper implements SqlHelper {
     }
 
     private function exec(db: SqlDatabase, query: String) : Bool {
-        if (!db.begin(query)) {
+        if (!db.exec(query)) {
             trace("database problem");
             return false;
         }
-        db.end();
         return true;
     }
 

--- a/env/js/sqlite_database.js
+++ b/env/js/sqlite_database.js
@@ -1,141 +1,152 @@
-    (function() {
+// -*- js-indent-level: 4 -*-
+(function() {
+    const crypto = require('crypto');
+    /* assume daff is available */
 
-	const SqliteDatabase = function(db,fname,Fiber) {
-	    this.db = db;
-            this.fname = fname;
-	    this.row = null;
-	    this.active = false;
-	    this.index2name = {};
-	    this.Fiber = Fiber;
-            // quoting rule for CSV is compatible with Sqlite
-            this.quoter = new daff.Csv();
-            this.view = new daff.SimpleView();
-	}
+    let DatabaseConstructor;
 
-        SqliteDatabase.prototype.getHelper = function() {
-            return new daff.SqliteHelper();
+    try {
+        // Attempt to use built-in node:sqlite (Node.js v23+)
+        // There's a warning in v23 which is annoying if daff
+        // is used as a utility.
+        process.removeAllListeners('warning').on('warning', err => {
+            if (err.name !== 'ExperimentalWarning' && !err.message.includes('experimental')) {
+                console.warn(err)
+            }
+        });
+        const { DatabaseSync } = require('node:sqlite');
+        DatabaseConstructor = DatabaseSync;
+    } catch (err) {
+        try {
+            // Fallback to better-sqlite3
+            DatabaseConstructor = require('better-sqlite3');
+        } catch (err) {
+            console.error("Problem: need sqlite3 support for node.");
+            console.error("  Option 1: use node v23 or later");
+            console.error("  Option 2: install better-sqlite3");
+            process.exit(1);
         }
-	
-	SqliteDatabase.prototype.getQuotedColumnName = function (name) {
-	    return this.quoter.renderCell(this.view, name, true);
-	}
-	
-	SqliteDatabase.prototype.getQuotedTableName = function (name) {
-	    return this.quoter.renderCell(this.view, name.toString(), true);
-	}
-	
-	SqliteDatabase.prototype.getColumns = function(name) {
-	    var fiber = this.Fiber.current;
-	    var qname = this.getQuotedColumnName(name);
-	    var self = this;
-	    this.db.all("pragma table_info("+qname+")", function(err,rows) {
-		var lst = [];
-		for (var i in rows) {
-		    var x = rows[i];
-                    var col = new daff.SqlColumn();
-                    col.setName(x['name']);
-                    col.setPrimaryKey(x['pk']>0);
-                    if (x['type']) {
-                        col.setType(x['type'],'sqlite');
-                    }
-		    lst.push(col);
-		    self.index2name[i] = x['name'];
-		}
-		fiber.run(lst);
-	    });
-	    return this.Fiber.yield();
-	}
-	
-	SqliteDatabase.prototype.exec = function(query,args) {
-	    var fiber = this.Fiber.current;
-	    if (args==null) {
-		this.db.run(query,function(err) {
-		    if (err) console.log(err);
-		    fiber.run(err==null);
-		});
-		return this.Fiber.yield();
-	    }
-	    var statement = this.db.run(query,args,function(err) {
-		if (err) console.log(err);
-		fiber.run(err==null);
-	    });
-	    return this.Fiber.yield();
-	}
-	
-	SqliteDatabase.prototype.beginRow = function(tab,row,order) {
-	    return this.begin("SELECT * FROM " + this.getQuotedColumnName(tab) + " WHERE rowid = ?",
-			      [row],
-			      order);
-	}
-	
-	SqliteDatabase.prototype.begin = function(query,args,order) {
-	    if (order!=null) {
-		this.index2name = {};
-		var len = order.length;
-		for (var i=0; i<len; i++) {
-		    this.index2name[i] = order[i];
-		}
-	    }
-	    var fiber = this.Fiber.current;
-	    this.active = true;
-	    var self = this;
-	    this.db.each(query,(args==null)?[]:args,function(err,row) {
-                var keys = Object.keys(row);
-                for (var i=0; i<keys.length; i++) {
-                    var val = row[keys[i]];
-                    // cannot do much with blobs - replace them with a short hash.
-                    if (Buffer.isBuffer(val)) {
-                        var crypto = require('crypto');
-                        var hash = crypto.createHash('md5').update(val).digest('hex');
-                        row[keys[i]] = '[buffer:' + hash + ']';
-                    }
-                }
-		if (err) {
-		    fiber.run([false,0]);
-		} else {
-		    fiber.run([true,row]);
-		}
-	    },function(err,n) {
-                if (err) {
-                    console.log(err);
-                }
-		fiber.run([false,n]);
-	    });
-	    return true;
-	}
+    }
 
-	SqliteDatabase.prototype.read = function() {
-	    if (!this.active) return false;
-	    var v = this.Fiber.yield();
-	    if (v[0]) {
-		this.row = v[1];
-		return true;
-	    }
-	    this.row = null;
-	    this.active = false;
-	    return false;
-	}
+    const SqliteDatabase = function(dbPath) {
+        this.db = new DatabaseConstructor(dbPath);
+        this.fname = dbPath;
+        this.row = null;
+        this.active = false;
+        this.index2name = {};
+        // quoting rule for CSV is compatible with Sqlite
+        this.quoter = new daff.Csv();
+        this.view = new daff.SimpleView();
+    };
 
-	SqliteDatabase.prototype.get = function(index) {
-	    return this.row[this.index2name[index]];
-	}
+    SqliteDatabase.prototype.getHelper = function() {
+        return new daff.SqliteHelper();
+    };
 
-	SqliteDatabase.prototype.end = function() {
-	    while (this.active) {
-		this.read();
-	    }
-	}
+    SqliteDatabase.prototype.getQuotedColumnName = function(name) {
+        return this.quoter.renderCell(this.view, name, true);
+    };
 
-	SqliteDatabase.prototype.rowid = function() {
-	    return "rowid";
-	}
+    SqliteDatabase.prototype.getQuotedTableName = function(name) {
+        return this.quoter.renderCell(this.view, name.toString(), true);
+    };
 
-	SqliteDatabase.prototype.getNameForAttachment = function() {
-	    return this.fname;
-	}
-
-        if (typeof exports !== 'undefined') {
-            exports.SqliteDatabase = SqliteDatabase;
+    SqliteDatabase.prototype.getColumns = function(name) {
+        const qname = this.getQuotedColumnName(name);
+        const stmt = this.db.prepare(`PRAGMA table_info(${qname})`);
+        const rows = stmt.all();
+        const lst = [];
+        for (let i = 0; i < rows.length; i++) {
+            const x = rows[i];
+            const col = new daff.SqlColumn();
+            col.setName(x.name);
+            col.setPrimaryKey(x.pk > 0);
+            if (x.type) {
+                col.setType(x.type, 'sqlite');
+            }
+            lst.push(col);
+            this.index2name[i] = x.name;
         }
+        return lst;
+    };
 
-    })();
+    SqliteDatabase.prototype.exec = function(query, args) {
+        try {
+            if (args == null) {
+                this.db.prepare(query).run();
+            } else {
+                this.db.prepare(query).run(...args);
+            }
+            return true;
+        } catch (err) {
+            console.log(err);
+            return false;
+        }
+    };
+
+    SqliteDatabase.prototype.beginRow = function(tab, row, order) {
+        return this.begin(
+            `SELECT * FROM ${this.getQuotedColumnName(tab)} WHERE rowid = ?`,
+            [row],
+            order
+        );
+    };
+
+    SqliteDatabase.prototype.begin = function(query, args, order) {
+        if (order != null) {
+            this.index2name = {};
+            const len = order.length;
+            for (let i = 0; i < len; i++) {
+                this.index2name[i] = order[i];
+            }
+        }
+        this.active = true;
+        const stmt = this.db.prepare(query);
+        this.iterator = stmt.iterate(...(args || []))[Symbol.iterator]();
+        return true;
+    };
+
+    SqliteDatabase.prototype.read = function() {
+        if (!this.active) return false;
+        const result = this.iterator.next();
+        if (result.done) {
+            this.row = null;
+            this.active = false;
+            return false;
+        }
+        const row = result.value;
+        const keys = Object.keys(row);
+        for (let i = 0; i < keys.length; i++) {
+            const val = row[keys[i]];
+            // cannot do much with blobs - replace them with a short hash.
+            if (Buffer.isBuffer(val)) {
+                const hash = crypto.createHash('md5').update(val).digest('hex');
+                row[keys[i]] = '[buffer:' + hash + ']';
+            }
+        }
+        this.row = row;
+        return true;
+    };
+
+    SqliteDatabase.prototype.get = function(index) {
+        return this.row[this.index2name[index]];
+    };
+
+    SqliteDatabase.prototype.end = function() {
+        while (this.active) {
+            this.read();
+        }
+    };
+
+    SqliteDatabase.prototype.rowid = function() {
+        return 'rowid';
+    };
+
+    SqliteDatabase.prototype.getNameForAttachment = function() {
+        return this.fname;
+    };
+
+    if (typeof exports !== 'undefined') {
+        exports.SqliteDatabase = SqliteDatabase;
+    }
+})();

--- a/env/js/util.js
+++ b/env/js/util.js
@@ -1,3 +1,4 @@
+// -*- js-indent-level: 4 -*-
 if (typeof exports !== 'undefined') {
     
     var tio = {};
@@ -7,8 +8,6 @@ if (typeof exports !== 'undefined') {
     var fs = require('fs');
     var exec = require('child_process').exec;
     var readline = null;
-    var Fiber = null;
-    var sqlite3 = null;
     var tty = null;
     
     tio.valid = function() {
@@ -73,11 +72,7 @@ if (typeof exports !== 'undefined') {
     }
 
     tio.openSqliteDatabase = function(path) {
-	if (Fiber) {
-	    return new coopy.SqliteDatabase(new sqlite3.Database(path),path,Fiber);
-	}
-	throw("run inside Fiber plz");
-	return null;
+        return new coopy.SqliteDatabase(path);
     }
 
     tio.sendToBrowser = function(html) {
@@ -186,23 +181,6 @@ if (typeof exports !== 'undefined') {
 
 if (typeof require != "undefined") {
     if (require.main === module) {
-	try {
-	    daff.run_daff_main();
-	} catch (e) {
-	    if (("" + e).indexOf("run inside Fiber plz") !== -1) {
-		try {
-		    Fiber = require('fibers');
-		    sqlite3 = require('sqlite3');
-		} catch (err) {
-		    // We don't have what we need for accessing the sqlite database.
-		    console.log("No sqlite3/fibers");
-		}
-		Fiber(function() {
-		    daff.run_daff_main();
-		}).run();
-            } else {
-                throw(e);
-            }
-	}
+	daff.run_daff_main();
     }
 }

--- a/harness/Native.hx
+++ b/harness/Native.hx
@@ -134,9 +134,7 @@ class Native {
 
     static public function wrap(callback : Dynamic) : Bool {
 #if js
-    untyped __js__("if (typeof Fiber == 'undefined') { globalThis.Fiber = require('fibers'); }");
-    untyped __js__("if (typeof sqlite3 == 'undefined') { globalThis.sqlite3 = require('sqlite3'); }");
-    untyped __js__("Fiber(function() { callback.body(); }).run();");
+    untyped __js__("(function() { callback.body(); })();");
     return true;
 #end
     return false;
@@ -155,7 +153,7 @@ class Native {
     static public function openSqlite(name: String) : coopy.SqlDatabase {
 #if js
         untyped __js__("if (typeof daff == 'undefined') { globalThis.daff = require('daff'); }");
-    return untyped __js__("new daff.SqliteDatabase(new sqlite3.Database(name),name,Fiber)");
+    return untyped __js__("new daff.SqliteDatabase(name)");
 #elseif python
     python.Syntax.pythonCode("daff = __import__('daff')");
     return python.Syntax.pythonCode("daff.SqliteDatabase(name,name)");

--- a/harness/SqlTest.hx
+++ b/harness/SqlTest.hx
@@ -59,8 +59,7 @@ class SqlTest extends haxe.unit.TestCase {
     }
 
     private function exec(db: coopy.SqlDatabase, query: String, ?args: Array<Dynamic>) {
-        db.begin(query,args);
-        db.end();
+        db.exec(query,args);
     }
 
     public function testRowDiffAndPatch() {
@@ -69,7 +68,7 @@ class SqlTest extends haxe.unit.TestCase {
         var st2 = new coopy.SqlTable(db,new coopy.SqlTableName("ver2"));
         var sc = new coopy.SqlCompare(db,st1,st2,null);
         var alignment = sc.apply();
-    
+
         var flags = new coopy.CompareFlags();
         var td = new coopy.TableDiff(alignment,flags);
         var out = Native.table([]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,579 +1,150 @@
 {
   "name": "daff",
-  "version": "1.3.47",
-  "lockfileVersion": 1,
+  "version": "1.3.50",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "optional": true
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "optional": true
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "optional": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "optional": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+  "packages": {
+    "": {
+      "name": "daff",
+      "version": "1.3.50",
+      "license": "MIT",
+      "bin": {
+        "daff": "bin/daff.js"
+      },
+      "devDependencies": {
+        "tmp": "0.x.x"
       }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
+      "dev": true,
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "optional": true
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "optional": true
-    },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "optional": true
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "optional": true
-    },
-    "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "optional": true,
-      "requires": {
-        "ms": "^2.1.1"
-      }
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "optional": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "optional": true
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "optional": true
-    },
-    "fibers": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.0.tgz",
-      "integrity": "sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==",
-      "optional": true,
-      "requires": {
-        "detect-libc": "^1.0.3"
-      }
-    },
-    "fs-minipass": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-      "optional": true,
-      "requires": {
-        "minipass": "^2.6.0"
-      }
-    },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "optional": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "requires": {
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "optional": true
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "optional": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "ignore-walk": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-      "optional": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
-    "ini": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
-      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
-      "optional": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "optional": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "optional": true
-    },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
+      "dev": true,
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "optional": true
-    },
-    "minipass": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "optional": true,
-      "requires": {
-        "minipass": "^2.9.0"
-      }
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "optional": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "optional": true
-    },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "optional": true
-    },
-    "needle": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
-      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
-      "optional": true,
-      "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      }
-    },
-    "node-pre-gyp": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
-      "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
-      "optional": true,
-      "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4"
-      }
-    },
-    "nopt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
-      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-      "optional": true,
-      "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
-      }
-    },
-    "npm-bundled": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
-      "optional": true,
-      "requires": {
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "npm-normalize-package-bin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-      "optional": true
-    },
-    "npm-packlist": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
-      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-      "optional": true,
-      "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1",
-        "npm-normalize-package-bin": "^1.0.1"
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "optional": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "optional": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "optional": true
-    },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
+      "dev": true,
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "optional": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "optional": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "optional": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-    },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "optional": true
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "optional": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "optional": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "optional": true,
-      "requires": {
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
         "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "optional": true
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "optional": true
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "optional": true
-    },
-    "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "optional": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "optional": true
-    },
-    "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "optional": true
-    },
-    "sqlite3": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.2.0.tgz",
-      "integrity": "sha512-roEOz41hxui2Q7uYnWsjMOTry6TcNUNmp8audCx18gF10P2NknwdpF+E+HKvz/F2NvPKGGBF4NGc+ZPQ+AABwg==",
-      "optional": true,
-      "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.11.0"
-      }
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "optional": true,
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "optional": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "optional": true
-    },
-    "tar": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-      "optional": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.8.6",
-        "minizlib": "^1.2.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.3"
-      }
-    },
-    "tmp": {
+    "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
       "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "rimraf": "^3.0.0"
       },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
+      "engines": {
+        "node": ">=8.17.0"
       }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "optional": true
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "optional": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "optional": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,12 +21,8 @@
   },
   "author": {
     "name": "Paul Fitzpatrick",
-    "email": "paul@robotrebuilt.com",
+    "email": "paulfitz@alum.mit.edu",
     "url": "http://paulfitz.github.io/"
-  },
-  "optionalDependencies": {
-    "fibers": "^5.0.0",
-    "sqlite3": "^4.0.0"
   },
   "scripts": {
     "prepare": "make js",

--- a/test/test_sqlite.js
+++ b/test/test_sqlite.js
@@ -1,21 +1,10 @@
+// -*- js-indent-level: 4 -*-
 var fs = require('fs');
 var daff = require('daff');
 var assert = require('assert');
 
-var Fiber = null;
-var sqlite3 = null;
-try {
-    Fiber = require('fibers');
-    sqlite3 = require('sqlite3');
-} catch (err) {
-    // We don't have what we need for accessing the sqlite database.
-    // Not an error.
-    console.log("No sqlite3/fibers");
-    return;
-}
-
-Fiber(function() {
-    var sql = new SqliteDatabase(new sqlite3.Database(':memory:'),null,Fiber);
+(function() {
+    var sql = new daff.SqliteDatabase(':memory:');
     sql.exec("CREATE TABLE ver1 (id INTEGER PRIMARY KEY, name TEXT)");
     sql.exec("CREATE TABLE ver2 (id INTEGER PRIMARY KEY, name TEXT)");
     sql.exec("INSERT INTO ver1 VALUES(?,?)",[1, "Paul"]);
@@ -29,7 +18,7 @@ Fiber(function() {
     var st2 = new daff.SqlTable(sql,"ver2")
     var sc = new daff.SqlCompare(sql,st1,st2)
     var alignment = sc.apply();
-    
+
     var flags = new daff.CompareFlags();
     var td = new daff.TableDiff(alignment,flags);
     var out = new daff.TableView([]);
@@ -40,4 +29,4 @@ Fiber(function() {
 				     ['->', 2, 'Naomi->Noemi'],
 				     ['---', 1, 'Paul']]);
     assert(target.isSimilar(out));
-}).run();
+})();


### PR DESCRIPTION
The `fiber` dependency in daff.js has always been rather silly. At the time I wrote the node code, `node-sqlite3` was the "standard" for working with sqlite3 in node, but it was async, and hard to integrate with translated code. Now, node has built-in support for sqlite3 on the way, and also `better-sqlite3` is a find sync interface.

Here I rework the node helper files to use `node:sqlite` if available, and `better-sqlite3` if not. I've removed all node dependencies, which I'm not very happy about, but daff sees a lot of use without sqlite3 so it seems bad to be forcing people to install dependencies that include compiled native code.